### PR TITLE
To use only one uberfire property definition

### DIFF
--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -20,8 +20,8 @@
 
   <properties>
     <version.org.jboss.integration-platform>6.0.0.CR17</version.org.jboss.integration-platform>
-    <version.org.uberfire.ext>0.5.0-SNAPSHOT</version.org.uberfire.ext>
     <version.org.uberfire>0.5.0-SNAPSHOT</version.org.uberfire>
+    <version.org.uberfire.ext>${version.org.uberfire}</version.org.uberfire.ext>
     <version.org.jboss.errai>3.0.3-SNAPSHOT</version.org.jboss.errai>
     <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
     <version.org.owasp.encoder>1.1</version.org.owasp.encoder>


### PR DESCRIPTION
This helps productization to manage the less properties if they are suppose to the same version.