### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/dashbuilder-webapp/src/main/resources/ErraiApp.properties
+++ b/dashbuilder-webapp/src/main/resources/ErraiApp.properties
@@ -14,3 +14,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
+errai.security.user_on_hostpage_enabled=true

--- a/dashbuilder-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/dashbuilder-webapp/src/main/webapp/WEB-INF/web.xml
@@ -43,6 +43,16 @@
     <url-pattern>*.erraiBus</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/dashbuilder.html</url-pattern>
+  </filter-mapping>
+
   <servlet>
     <servlet-name>ErraiServlet</servlet-name>
     <servlet-class>org.jboss.errai.bus.server.servlet.DefaultBlockingServlet</servlet-class>


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.