### PR TITLE
BZ-1244654 add productized profile to exclude distros-cdi1.0 in order…

### DIFF
--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -24,6 +24,8 @@
     <version.org.jboss.integration-platform>6.0.0.CR26</version.org.jboss.integration-platform>
     <version.org.uberfire>0.7.0-SNAPSHOT</version.org.uberfire>
     <version.org.jboss.errai>3.2.0-SNAPSHOT</version.org.jboss.errai>
+    <!-- Version of Errai compatible with CDI 1.0. Few artifacts in this version are used for CDI 1.0 compatible WAR distributions. -->
+    <version.org.jboss.errai.cdi10-compatible>3.0.5.Final</version.org.jboss.errai.cdi10-compatible>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.org.owasp.encoder>1.1</version.org.owasp.encoder>
     <version.com.google.gwt>2.7.0</version.com.google.gwt>
@@ -88,6 +90,12 @@
         <type>pom</type>
         <version>${version.org.jboss.errai}</version>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+       <groupId>org.jboss.errai</groupId>
+       <artifactId>errai-weld-integration</artifactId>
+       <version>${version.org.jboss.errai.cdi10-compatible}</version>
       </dependency>
 
       <dependency>

--- a/dashbuilder-distros-cdi1.0/pom.xml
+++ b/dashbuilder-distros-cdi1.0/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-weld-integration</artifactId>
-      <version>3.0.4.Final</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
… to avoid old errai deps
This is for https://bugzilla.redhat.com/show_bug.cgi?id=1244654 
Please have a look if this helps.
The product want to avoid have the old errai deps as a dependency. 
If we could remove the old errai deps , that would be better and feel free to reject this PR.