### PR TITLE
 Disable SQL data sets until the jOOQ library is replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ Architecture
 * Decoupled client & server layers. Ability to build pure lightweight client dashboards.
 * Ability to push & handle data sets on client for better performance.
 * Based on <a href="http://www.uberfireframework.org" target="_blank">Uberfire</a>, a framework for building rich workbench styled apps on the web.
+* Data provider for the definition of data sets stored into SQL databases.
 
 Change log
 ==========
 
 0.3.0
 
-* New provider for the definition of data sets stored into SQL databases.
 * New provider for the retrieval of data stored into Elastic Search nodes.
 * New displayer for showing single value metrics.
 * Added new displayer subtypes: bar (stacked), pie (3d, donut), line (smooth)
 * Support for real-time dashboards. Displayer refresh settings.
 
 * New data set editor UI module:
-    - Creation of SQL, Bean, CSV & elastic search data set definitions
+    - Creation of Bean, CSV & Elastic Search data set definitions
     - Data set retrieval testing and preview
     - Filter, sort and export the data previews
 

--- a/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/widgets/editors/DataSetProviderTypeEditor.java
+++ b/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/widgets/editors/DataSetProviderTypeEditor.java
@@ -69,6 +69,10 @@ public class DataSetProviderTypeEditor extends AbstractDataSetDefEditor implemen
         final Map<DataSetProviderType, ImageListEditor.Entry> providerEditorValues
                 = new EnumMap<DataSetProviderType, ImageListEditor.Entry>(DataSetProviderType.class);
         for (final DataSetProviderType type : DataSetProviderType.values()) {
+            if (DataSetProviderType.SQL == type) {
+                // Disable SQL data set creation until the jOOQ library is replaced
+                continue;
+            }
             final Image _image = buildTypeSelectorWidget(type);
             final String _heading = buildTypeSelectorHeading(type);
             final String _text = buildTypeSelectorText(type);


### PR DESCRIPTION
The jOOQ lib used by the current SQL provider implementation does not fit the ASL 2.0 terms since cannot be used in commercial DBs. In dashbuilder 0.3.0.Final community release we are putting the creation of SQL data sets on hold until a new SQL provider implementation is ready as a replacement of the jOOQ based implementation.