### PR TITLE
upgrade to jboss-ip-bom 6.0.0.CR28

### DIFF
--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -21,7 +21,8 @@
   <properties>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
 
-    <version.org.jboss.integration-platform>6.0.0.CR27</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.0.CR28</version.org.jboss.integration-platform>
+    <version.org.jgroups>3.2.13.Final</version.org.jgroups>
     <version.org.uberfire>0.7.0-SNAPSHOT</version.org.uberfire>
     <version.org.jboss.errai>3.2.0-SNAPSHOT</version.org.jboss.errai>
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>
@@ -64,6 +65,12 @@
         <type>pom</type>
         <version>${version.org.jboss.integration-platform}</version>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jgroups</groupId>
+        <artifactId>jgroups</artifactId>
+        <version>${version.org.jgroups}</version>
       </dependency>
 
       <!-- UberFire -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-    <version>6.0.0.CR27</version>
+    <version>6.0.0.CR28</version>
   </parent>
 
   <groupId>org.dashbuilder</groupId>


### PR DESCRIPTION
we had to put temporarily org.jgroups:jgroups:3.1.13.Final to dashbuilder-deps as this artifact doesn't exist in the version inherited by the IP BOM CR28 (3.1.14.Final).
This will be a temporary workaround.