### PR TITLE
SQL provider fixes

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetFilterTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetFilterTest.java
@@ -18,9 +18,7 @@ package org.dashbuilder.dataset;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
 import javax.inject.Inject;
 
 import org.dashbuilder.dataset.backend.BackendDataSetManager;
@@ -71,6 +69,27 @@ public class DataSetFilterTest {
         dataSetManager.registerDataSet(dataSet, preProcessors);
 
         dataSetFormatter = new DataSetFormatter();
+    }
+
+    @Test
+    public void testColumnTypes() throws Exception {
+
+        DataSet result = dataSetManager.lookupDataSet(
+                DataSetFactory.newDataSetLookupBuilder()
+                        .dataset(EXPENSE_REPORTS)
+                        .column(COLUMN_CITY)
+                        .column(COLUMN_AMOUNT)
+                        .column(COLUMN_DATE)
+                        .buildLookup());
+
+        assertThat(result.getColumnByIndex(0).getColumnType()).isEqualTo(ColumnType.LABEL);
+        assertThat(result.getColumnByIndex(1).getColumnType()).isEqualTo(ColumnType.NUMBER);
+        assertThat(result.getColumnByIndex(2).getColumnType()).isEqualTo(ColumnType.DATE);
+        assertThat(String.class.isAssignableFrom(result.getValueAt(0, 0).getClass())).isTrue();
+        assertThat(Double.class.isAssignableFrom(result.getValueAt(0, 1).getClass())).isTrue();
+        assertThat(java.util.Date.class.equals(result.getValueAt(0,2).getClass()) ||
+                java.sql.Date.class.equals(result.getValueAt(0, 2).getClass()) ||
+                java.sql.Timestamp.class.equals(result.getValueAt(0,2).getClass())).isTrue();
     }
 
     @Test

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
@@ -897,7 +897,8 @@ public class SQLDataSetProvider implements DataSetProvider {
                 }
             }
 
-            // Format the data set values according to each column type
+            // Process the data set values according to each column type and the JDBC dialect
+            Dialect dialect = JDBCUtils.dialect(conn);
             for (DataColumn column : dataSet.getColumns()) {
                 ColumnType columnType = column.getColumnType();
                 List values = column.getValues();
@@ -917,12 +918,29 @@ public class SQLDataSetProvider implements DataSetProvider {
                             values.add(j, dateObj);
                         }
                     }
+                    else {
+                        for (int j=0; j<values.size(); j++) {
+                            Object value = dialect.convertToString(values.remove(j));
+                            values.add(j, value);
+                        }
+                    }
                 }
-                if (ColumnType.NUMBER.equals(columnType)) {
+                else if (ColumnType.NUMBER.equals(columnType)) {
                     for (int j=0; j<values.size(); j++) {
-                        // Convert to double any numeric value
-                        Number num = (Number) values.remove(j);
-                        values.add(j, num != null ? num.doubleValue() : null);
+                        Object value = dialect.convertToDouble(values.remove(j));
+                        values.add(j, value);
+                    }
+                }
+                else if (ColumnType.DATE.equals(columnType)) {
+                    for (int j=0; j<values.size(); j++) {
+                        Object value = dialect.convertToDate(values.remove(j));
+                        values.add(j, value);
+                    }
+                }
+                else {
+                    for (int j=0; j<values.size(); j++) {
+                        Object value = dialect.convertToString(values.remove(j));
+                        values.add(j, value);
                     }
                 }
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
@@ -374,7 +374,10 @@ public class SQLDataSetProvider implements DataSetProvider {
     }
 
     protected void _appendFilterBy(SQLDataSetDef def, ColumnFilter filter, Select _query) {
-        _query.where(_createCondition(def, filter));
+        Condition condition = _createCondition(def, filter);
+        if (condition != null) {
+            _query.where(condition);
+        }
     }
 
     protected Condition _createCondition(SQLDataSetDef def, ColumnFilter filter) {

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/DefaultDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/DefaultDialect.java
@@ -386,8 +386,12 @@ public class DefaultDialect implements Dialect {
 
     @Override
     public String getIsEqualsToConditionSQL(String column, Object param) {
-        String paramStr = getParameterSQL(param);
-        return column + " = " + paramStr;
+        if (param == null) {
+            return getIsNullConditionSQL(column);
+        } else {
+            String paramStr = getParameterSQL(param);
+            return column + " = " + paramStr;
+        }
     }
 
     @Override

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/Dialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/Dialect.java
@@ -63,6 +63,12 @@ public interface Dialect {
 
     String getColumnTypeSQL(Column column);
 
+    String convertToString(Object value);
+
+    double convertToDouble(Object value);
+
+    Date convertToDate(Object value);
+
     String[] getExcludedColumns();
 
     String getTableSQL(SQLStatement<?> stmt);

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/OracleDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/OracleDialect.java
@@ -15,13 +15,13 @@
  */
 package org.dashbuilder.dataprovider.backend.sql.dialect;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.dashbuilder.dataprovider.backend.sql.model.Column;
 import org.dashbuilder.dataprovider.backend.sql.model.DynamicDateColumn;
 import org.dashbuilder.dataprovider.backend.sql.model.Select;
-import org.dashbuilder.dataset.ColumnType;
 import org.dashbuilder.dataset.group.DateIntervalType;
 
 /**
@@ -64,6 +64,13 @@ public class OracleDialect extends DefaultDialect {
                 return "VARCHAR2(" + column.getLength() + ")";
             }
         }
+    }
+
+    @Override
+    public Date convertToDate(Object value) {
+        // ((oracle.sql.TIMESTAMP) value).dateValue()
+        Object date = invokeMethod(value, "dateValue", null);
+        return super.convertToDate(date);
     }
 
     @Override

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/OracleLegacyDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/OracleLegacyDialect.java
@@ -34,20 +34,24 @@ public class OracleLegacyDialect extends OracleDialect {
 
         int offset = select.getOffset();
         int limit = select.getLimit();
-        if (limit <= 0 && offset <= 0) {
-            return sql;
-        }
 
-        String result = "SELECT * FROM (SELECT Q.*, ROWNUM RN FROM (" + sql + ") Q) WHERE ";
         if (offset > 0 && limit > 0) {
-            result += "RN > " + offset + " AND RN <= "  + (offset + limit);
+            return "SELECT * FROM (SELECT Q.*, ROWNUM RN FROM (" + sql + ") Q WHERE ROWNUM <= " + (offset + limit) + ") WHERE RN > " + offset;
         }
         else if (offset > 0) {
-            result += "RN >= " + offset;
+            return "SELECT * FROM (" + sql + ") WHERE ROWNUM > " + offset;
         }
         else if (limit > 0) {
-            result += "RN <= " + limit;
+            return "SELECT * FROM (" + sql + ") WHERE ROWNUM <= " + limit;
         }
-        return result;
+        else {
+            return sql;
+        }
+    }
+
+    @Override
+    public String getOffsetLimitSQL(Select select) {
+        return null;
     }
 }
+

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SybaseASEDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SybaseASEDialect.java
@@ -45,6 +45,13 @@ public class SybaseASEDialect extends DefaultDialect {
         }
     }
 
+    @Override
+    public Date convertToDate(Object value) {
+        // new Date( ((com.sybase.jdbc4.tds.SybTimestamp) value).getTime() )
+        Long time = (Long) invokeMethod(value, "getTime", null);
+        return new Date(time);
+    }
+
     SimpleDateFormat sybaseDateFormat = new SimpleDateFormat("yyyyMMdd HH:mm:ss");
 
     @Override

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/model/Select.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/model/Select.java
@@ -104,15 +104,19 @@ public class Select extends SQLStatement<Select> {
     }
 
     public Select where(Condition condition) {
-        if (condition instanceof CoreCondition) {
-            fix(((CoreCondition) condition).getColumn());
+        if (condition != null) {
+            if (condition instanceof CoreCondition) {
+                fix(((CoreCondition) condition).getColumn());
+            }
+            wheres.add(condition);
         }
-        wheres.add(condition);
         return this;
     }
 
     public Select groupBy(Column column) {
-        groupBys.add(fix(column));
+        if (column != null) {
+            groupBys.add(fix(column));
+        }
         return this;
     }
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetDefTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetDefTest.java
@@ -105,7 +105,7 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
         assertThat(dataSet.getValueAt(0, 0)).isEqualTo("Engineering");
         assertThat(dataSet.getValueAt(0, 1)).isEqualTo("Roxie Foraker");
         assertThat(dataSet.getValueAt(0, 2)).isEqualTo(120.35d);
-        assertThat(dataSet.getValueAt(0, 3).toString()).isEqualTo("2015-12-11 12:00:00.0");
+        assertThat(dataSetFormatter.formatValueAt(dataSet, 0, 3)).isEqualTo("12/11/15 12:00");
     }
 
     @Test

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
@@ -180,8 +180,10 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         subTest.testNOTExpression();
         subTest.testORExpression();
         subTest.testORExpressionMultilple();
+        subTest.testLogicalExprNonEmpty();
         subTest.testCombinedExpression();
         subTest.testCombinedExpression2();
+        subTest.testCombinedExpression3();
         subTest.testLikeOperatorNonCaseSensitive();
 
         // Skip this test since MySQL,SQLServer & Sybase are non case sensitive by default

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
@@ -171,6 +171,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         DataSetFilterTest subTest = new DataSetFilterTest();
         subTest.dataSetManager = dataSetManager;
         subTest.dataSetFormatter = dataSetFormatter;
+        subTest.testColumnTypes();
         subTest.testFilterByString();
         subTest.testFilterByDate();
         subTest.testFilterByNumber();

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTestSuite.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTestSuite.java
@@ -22,7 +22,7 @@ import org.junit.Before;
 
 public class SQLTestSuite extends SQLDataSetTestBase {
 
-    private <T extends SQLDataSetTestBase> T setUp(T test) throws Exception {
+    protected <T extends SQLDataSetTestBase> T setUp(T test) throws Exception {
         test.dataSetManager = dataSetManager;
         test.dataSetFormatter = dataSetFormatter;
         test.dataSetDefRegistry = dataSetDefRegistry;
@@ -33,7 +33,7 @@ public class SQLTestSuite extends SQLDataSetTestBase {
         return test;
     }
 
-    private List<SQLDataSetTestBase> sqlTestList = new ArrayList<SQLDataSetTestBase>();
+    protected List<SQLDataSetTestBase> sqlTestList = new ArrayList<SQLDataSetTestBase>();
 
     @Before
     public void setUp() throws Exception {

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/filter/LogicalExprFilter.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/filter/LogicalExprFilter.java
@@ -36,12 +36,14 @@ public class LogicalExprFilter extends ColumnFilter {
         super(columnId);
         this.logicalOperator = operator;
         setLogicalTerms(terms);
+        setColumnId(columnId);
     }
 
     public LogicalExprFilter(String columnId, LogicalExprType operator, ColumnFilter... terms) {
         super(columnId);
         this.logicalOperator = operator;
         setLogicalTerms(terms);
+        setColumnId(columnId);
     }
 
     public void setColumnId(String columnId) {

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/filter/LogicalFunction.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/filter/LogicalFunction.java
@@ -37,6 +37,10 @@ public class LogicalFunction extends DataSetFunction {
     }
 
     public boolean pass() {
+        if (functionTerms .isEmpty()) {
+            return true;
+        }
+
         LogicalExprType type = logicalFunctionFilter.getLogicalOperator();
 
         if (LogicalExprType.NOT.equals(type)) {


### PR DESCRIPTION
Some fixes to critical bugs reported on the SQL provider.

BZ-1263567: Exception "no marshalling definition available for type:com.sybase.jdbc4.tds.SybTimestamp"
BZ-1263085: Exception "no marshalling definition available for type:oracle.sql.TIMESTAMP"
BZ-1263564: Oracle11gR2: can't get metadata on specified dataset
DASHBUILDE-40: Data set filter binary operations fail when the parameter set is empty

