### PR TITLE
DASHBUILDE-41: Add MonetDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,49 @@ Architecture
 Change log
 ==========
 
+master
+
+* MonetDB support added to the SQL provider.  
+  (The provider has been tested under the MonetDB 11.21.5 release)
+
+0.3.1
+
+Some fixes:
+
+* https://issues.jboss.org/browse/DASHBUILDE-28
+  Data Set preview table should be wrapped in scroll panel.
+  
+* https://issues.jboss.org/browse/DASHBUILDE-37
+  Data set lookup pre-processors
+  
+* https://issues.jboss.org/browse/DASHBUILDE-38
+  Marshalling errors in DevMode with Strings filtering.
+
 0.3.0
 
-* New provider for the definition of data sets stored into SQL databases.
-* New provider for the retrieval of data stored into Elastic Search nodes.
-* New displayer for showing single value metrics.
-* Added new displayer subtypes: bar (stacked), pie (3d, donut), line (smooth)
-* Support for real-time dashboards. Displayer refresh settings.
+* New provider for the definition of data sets stored into SQL databases. 
+  The following is the list of tested and supported DBs: 
+  
+  - MySQL 5.5
+  - Postgres 9.2
+  - H2 1.3.168+
+  - Oracle 12c and 11gR2
+  - IBM DB2 9.7 and 10.5
+  - Sybase ASE 15.7
 
+* New provider for the retrieval of data stored into Elastic Search nodes.
+  The provider has been tested under Elastic Search 1.7.1 release.
+   
 * New data set editor UI module:
-    - Creation of SQL, Bean, CSV & elastic search data set definitions
+    - Creation of SQL, Bean, CSV and Elastic Search data set definitions
     - Data set retrieval testing and preview
     - Filter, sort and export the data previews
+
+* New displayer for showing single value metrics.
+
+* Added new displayer subtypes: bar (stacked), pie (3d, donut), line (smooth)
+
+* Support for real-time dashboards. Displayer refresh settings.
 
 * Displayer editor data set lookup enhancements:
     - Filter editor for retrieving only a data subset.

--- a/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetGroupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetGroupTest.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import org.dashbuilder.dataset.date.DayOfWeek;
 import org.dashbuilder.dataset.date.Month;
 import org.dashbuilder.dataset.filter.FilterFactory;
+import org.dashbuilder.dataset.group.DataSetGroup;
 import org.dashbuilder.dataset.group.DateIntervalType;
 import org.dashbuilder.dataset.sort.SortOrder;
 import org.dashbuilder.test.ShrinkWrapHelper;
@@ -114,6 +115,28 @@ public class DataSetGroupTest {
                 .column(COUNT, "Occurrences")
                 .column(COLUMN_AMOUNT, SUM, "totalAmount")
                 .buildLookup());
+
+        //printDataSet(result);
+        assertDataSetValues(result, dataSetFormatter, new String[][]{
+                {"2012", "13.00", "6,126.13"},
+                {"2013", "11.00", "5,252.96"},
+                {"2014", "11.00", "4,015.48"},
+                {"2015", "15.00", "7,336.69"}
+        }, 0);
+
+        DataSetLookup lookup = DataSetFactory.newDataSetLookupBuilder()
+                .dataset(EXPENSE_REPORTS)
+                .group(COLUMN_DATE).dynamic(YEAR, true)
+                .column(COLUMN_DATE)
+                .column(COUNT, "Occurrences")
+                .column(COLUMN_AMOUNT, SUM, "totalAmount")
+                .buildLookup();
+
+        // Test required for those databases that support alias as statements (f.i: MySQL. Postgres or MonetDB)
+        DataSetGroup group = lookup.getOperation(0);
+        group.getColumnGroup().setColumnId(null);
+        group.getGroupFunctions().get(0).setColumnId(null);
+        result = dataSetManager.lookupDataSet(lookup);
 
         //printDataSet(result);
         assertDataSetValues(result, dataSetFormatter, new String[][]{

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2014 JBoss Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.dashbuilder</groupId>
+    <artifactId>dashbuilder-dataset-sql-tests</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>dashbuilder-dataset-sql-tests-monetdb</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Dashbuilder SQL Tests MonetDB</name>
+
+  <properties>
+    <monetdb.driver.path>${basedir}/src/test/lib/monetdb-jdbc-2.17.jar</monetdb.driver.path>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.monetdb</groupId>
+        <artifactId>jdbc</artifactId>
+        <scope>system</scope>
+        <systemPath>${monetdb.driver.path}</systemPath>
+        <version>1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.monetdb</groupId>
+      <artifactId>jdbc</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/java/org/dashbuilder/dataprovider/backend/sql/MonetDBTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/java/org/dashbuilder/dataprovider/backend/sql/MonetDBTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.backend.sql;
+
+import org.junit.Test;
+
+public class MonetDBTest extends SQLTestSuite {
+
+    @Test
+    public void testAll() throws Exception {
+        super.testAll();
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/java/org/dashbuilder/dataprovider/backend/sql/MonetDBTestSettings.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/java/org/dashbuilder/dataprovider/backend/sql/MonetDBTestSettings.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.backend.sql;
+
+import javax.enterprise.inject.Specializes;
+import javax.sql.DataSource;
+
+import nl.cwi.monetdb.jdbc.MonetDataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.dashbuilder.dataset.def.SQLDataSetDef;
+
+@Specializes
+public class MonetDBTestSettings extends DatabaseTestSettings {
+
+    @Override
+    public String getDatabaseType() {
+        return MONETDB;
+    }
+
+    @Override
+    public SQLDataSourceLocator getDataSourceLocator() {
+        return new SQLDataSourceLocator() {
+            public DataSource lookup(SQLDataSetDef def) throws Exception {
+                String url = connectionSettings.getProperty("url");
+                String user = connectionSettings.getProperty("user");
+                String password = connectionSettings.getProperty("password");
+
+                MonetDataSource ds = new MonetDataSource();
+                ds.setDatabaseName(url);
+                if (!StringUtils.isBlank(user)) {
+                    ds.setUser(user);
+                }
+                if (!StringUtils.isBlank(password)) {
+                    ds.setPassword(password);
+                }
+                return ds;
+            }
+        };
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/resources/testdb-monetdb.properties
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-monetdb/src/test/resources/testdb-monetdb.properties
@@ -1,0 +1,3 @@
+url=jdbc:monetdb://104.155.41.56:50000/voc
+user=monetdb
+password=$monetdb123

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mysql/src/test/resources/testdb-mysql.properties
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mysql/src/test/resources/testdb-mysql.properties
@@ -1,3 +1,4 @@
 url=jdbc:mysql://localhost:3306/dashbuilder
 user=root
+password=root
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -25,6 +25,7 @@
     <module>dashbuilder-dataset-sql-tests-sqlserver</module>
     <module>dashbuilder-dataset-sql-tests-db2</module>
     <module>dashbuilder-dataset-sql-tests-sybase</module>
+    <module>dashbuilder-dataset-sql-tests-monetdb</module>
   </modules-->
 
   <dependencies>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/JDBCUtils.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/JDBCUtils.java
@@ -30,6 +30,7 @@ import org.dashbuilder.dataprovider.backend.sql.dialect.DB2Dialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.DefaultDialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.Dialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.H2Dialect;
+import org.dashbuilder.dataprovider.backend.sql.dialect.MonetDBDialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.MySQLDialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.OracleDialect;
 import org.dashbuilder.dataprovider.backend.sql.dialect.OracleLegacyDialect;
@@ -54,6 +55,7 @@ public class JDBCUtils {
     public static final Dialect SQLSERVER = new SQLServerDialect();
     public static final Dialect DB2 = new DB2Dialect();
     public static final Dialect SYBASE_ASE = new SybaseASEDialect();
+    public static final Dialect MONETDB = new MonetDBDialect();
 
     private static final Logger log = LoggerFactory.getLogger(JDBCUtils.class);
 
@@ -124,6 +126,9 @@ public class JDBCUtils {
         if (url.contains(":sybase:")) {
             return SYBASE_ASE;
         }
+        if (url.contains(":monetdb:")) {
+            return MONETDB;
+        }
         return DEFAULT;
     }
 
@@ -149,6 +154,9 @@ public class JDBCUtils {
         if (dbName.contains("ase") || dbName.contains("adaptive")) {
             return SYBASE_ASE;
         }
+        if (dbName.contains("monet")) {
+            return MONETDB;
+        }
         return DEFAULT;
     }
 
@@ -172,7 +180,7 @@ public class JDBCUtils {
         return columnList;
     }
 
-    public static String changeCase(Connection connection, String id) {
+    public static String fixCase(Connection connection, String id) {
         try {
             DatabaseMetaData meta = connection.getMetaData();
             if (meta.storesLowerCaseIdentifiers()) {

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetProvider.java
@@ -265,7 +265,7 @@ public class SQLDataSetProvider implements DataSetProvider {
 
         if (def.getColumns() != null) {
             for (DataColumnDef column : def.getColumns()) {
-                String columnId = JDBCUtils.changeCase(conn, column.getId());
+                String columnId = JDBCUtils.fixCase(conn, column.getId());
                 columnIds.add(columnId);
                 columnTypes.add(column.getColumnType());
             }
@@ -1000,11 +1000,15 @@ public class SQLDataSetProvider implements DataSetProvider {
             for (GroupFunction gf : gOp.getGroupFunctions()) {
 
                 String sourceId = gf.getSourceId();
-                String targetId = gf.getColumnId();
-                if (sourceId == null) {
+                if (StringUtils.isBlank(sourceId)) {
                     sourceId = metadata.getColumnId(0);
                 } else {
                     _assertColumnExists(sourceId);
+                }
+
+                String targetId = gf.getColumnId();
+                if (StringUtils.isBlank(targetId)) {
+                    targetId = sourceId;
                 }
 
                 if (cg != null && cg.getSourceId().equals(sourceId) && gf.getFunction() == null) {
@@ -1047,7 +1051,7 @@ public class SQLDataSetProvider implements DataSetProvider {
 
 
         protected int _assertColumnExists(String columnId) {
-            String targetId = JDBCUtils.changeCase(conn, columnId);
+            String targetId = JDBCUtils.fixCase(conn, columnId);
             for (int i = 0; i < metadata.getNumberOfColumns(); i++) {
                 if (metadata.getColumnId(i).equals(targetId)) {
                     return i;
@@ -1064,7 +1068,7 @@ public class SQLDataSetProvider implements DataSetProvider {
         }
 
         protected ColumnType _getColumnType(String columnId) {
-            String _col = JDBCUtils.changeCase(conn, columnId);
+            String _col = JDBCUtils.fixCase(conn, columnId);
             return metadata.getColumnType(_col);
         }
     }

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/Dialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/Dialect.java
@@ -111,7 +111,9 @@ public interface Dialect {
 
     String getColumnNameSQL(String name);
 
-    String getColumnAliasSQL(String alias);
+    String getAliasForColumnSQL(String alias);
+
+    String getAliasForStatementSQL(String alias);
 
     String getConditionSQL(Condition condition);
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/MonetDBDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/MonetDBDialect.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.backend.sql.dialect;
+
+import org.dashbuilder.dataprovider.backend.sql.model.Column;
+
+public class MonetDBDialect extends DefaultDialect {
+
+    @Override
+    public boolean allowAliasInStatements() {
+        return true;
+    }
+
+    @Override
+    public String getColumnTypeSQL(Column column) {
+        switch (column.getType()) {
+            case NUMBER: {
+                return "NUMERIC(18,3)";
+            }
+            case DATE: {
+                return "TIMESTAMP";
+            }
+            default: {
+                return "VARCHAR(" + column.getLength() + ")";
+            }
+        }
+    }
+
+    @Override
+    public String getAliasForColumnSQL(String alias) {
+        return "AS \"" + alias + "\"";
+    }
+
+    @Override
+    public String getAliasForStatementSQL(String alias) {
+        return "\"" + alias + "\"";
+    }
+
+    @Override
+    public String getColumnCastSQL(Column column) {
+        String columnSQL = getColumnSQL(column);
+        int length = column.getLength() < 10 ? 10 : column.getLength();
+        return "CAST(" + columnSQL + " AS VARCHAR(" + length + "))";
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/MySQLDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/MySQLDialect.java
@@ -47,8 +47,18 @@ public class MySQLDialect extends DefaultDialect {
     }
 
     @Override
-    public String getColumnAliasSQL(String alias) {
+    public boolean allowAliasInStatements() {
+        return true;
+    }
+
+    @Override
+    public String getAliasForColumnSQL(String alias) {
         return "AS `" + alias + "`";
+    }
+
+    @Override
+    public String getAliasForStatementSQL(String alias) {
+        return "`" + alias + "`";
     }
 
     @Override

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/PostgresDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/PostgresDialect.java
@@ -46,8 +46,18 @@ public class PostgresDialect extends DefaultDialect {
     }
 
     @Override
-    public String getColumnAliasSQL(String alias) {
+    public boolean allowAliasInStatements() {
+        return true;
+    }
+
+    @Override
+    public String getAliasForColumnSQL(String alias) {
         return "AS \"" + alias + "\"";
+    }
+
+    @Override
+    public String getAliasForStatementSQL(String alias) {
+        return "\"" + alias + "\"";
     }
 
     @Override

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SQLServerDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SQLServerDialect.java
@@ -81,7 +81,7 @@ public class SQLServerDialect extends DefaultDialect {
                 select.orderBy(sortColumns);
             }
         }
-        return super.getCountQuerySQL(select);
+        return "SELECT COUNT(*) FROM (" + select.getSQL() + ") \"dbSQL\"";
     }
 
     /**

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SybaseASEDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/dialect/SybaseASEDialect.java
@@ -78,22 +78,6 @@ public class SybaseASEDialect extends DefaultDialect {
         return super.getConcatFunctionSQL(columns, begin, end, separator);
     }
 
-    @Override
-    public String getCountQuerySQL(Select select) {
-        if (!select.getOrderBys().isEmpty()) {
-            List<SortColumn> sortColumns = new ArrayList<SortColumn>();
-            sortColumns.addAll(select.getOrderBys());
-            try {
-                // ORDER BY clauses within nested queries are not supported
-                select.getOrderBys().clear();
-                return "SELECT COUNT(*) FROM (" + select.getSQL() + ") \"dbSQL\"";
-            } finally {
-                select.orderBy(sortColumns);
-            }
-        }
-        return super.getCountQuerySQL(select);
-    }
-
     /**
      * Sybase ASE pagination queries are resolved as follows:
      *
@@ -135,5 +119,4 @@ public class SybaseASEDialect extends DefaultDialect {
     public String getOffsetLimitSQL(Select select) {
         return null;
     }
-
 }

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/model/SQLStatement.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/backend/sql/model/SQLStatement.java
@@ -56,10 +56,6 @@ public class SQLStatement<T extends SQLStatement> {
     }
 
     protected Column fix(Column column) {
-        // Remove alias
-        if (column.getName().equals(column.getAlias())) {
-            column.setAlias(null);
-        }
         // Fix column name to match DB case settings
         String name = fix(column.getName());
         column.setName(name);
@@ -67,6 +63,6 @@ public class SQLStatement<T extends SQLStatement> {
     }
 
     protected String fix(String id) {
-        return JDBCUtils.changeCase(connection, id);
+        return JDBCUtils.fixCase(connection, id);
     }
 }

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/DatabaseTestSettings.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/DatabaseTestSettings.java
@@ -35,6 +35,7 @@ public class DatabaseTestSettings {
     public static final String DB2 = "db2";
     public static final String SQLSERVER = "sqlserver";
     public static final String SYBASE = "sybase";
+    public static final String MONETDB = "monetdb";
 
     protected Properties connectionSettings;
 
@@ -93,6 +94,10 @@ public class DatabaseTestSettings {
 
     public boolean isSybase() {
         return SYBASE.equals(getDatabaseType());
+    }
+
+    public boolean isMonetDB() {
+        return MONETDB.equals(getDatabaseType());
     }
 
     public String getDatabaseType() {

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetDefTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLDataSetDefTest.java
@@ -35,7 +35,9 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
 
     @Override
     public void testAll() throws Exception {
-        testAllColumns();
+        if (!testSettings.isMonetDB()) {
+            testAllColumns();
+        }
         testSQLDataSet();
         testColumnSet();
         testFilters();
@@ -94,7 +96,9 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
 
         DataSetMetadata metadata = dataSetManager.getDataSetMetadata("expense_reports_columnset");
         assertThat(metadata.getNumberOfColumns()).isEqualTo(4);
-        assertThat(metadata.getEstimatedSize()).isEqualTo(4300);
+        if (!testSettings.isMonetDB()) {
+            assertThat(metadata.getEstimatedSize()).isEqualTo(4300);
+        }
 
         DataSet dataSet = dataSetManager.lookupDataSet(
                 DataSetFactory.newDataSetLookupBuilder()
@@ -118,7 +122,9 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
 
         DataSetMetadata metadata = dataSetManager.getDataSetMetadata("expense_reports_filtered");
         assertThat(metadata.getNumberOfColumns()).isEqualTo(4);
-        assertThat(metadata.getEstimatedSize()).isEqualTo(516);
+        if (!testSettings.isMonetDB()) {
+            assertThat(metadata.getEstimatedSize()).isEqualTo(516);
+        }
 
         DataSet dataSet = dataSetManager.lookupDataSet(
                 DataSetFactory.newDataSetLookupBuilder()

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
@@ -196,7 +196,9 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         subTest.dataSetManager = dataSetManager;
         subTest.dataSetFormatter = dataSetFormatter;
         subTest.testGroupSelectionFilter();
-        subTest.testNestedGroupFromMultipleSelection();
+        if (!testSettings.isMonetDB()) {
+            subTest.testNestedGroupFromMultipleSelection();
+        }
         subTest.testNestedGroupRequiresSelection();
         subTest.testThreeNestedLevels();
         subTest.testNoResultsSelection();

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DataSetLookupEditor.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DataSetLookupEditor.java
@@ -248,15 +248,12 @@ public class DataSetLookupEditor implements IsWidget,
             else {
                 groupOp.setColumnGroup(new ColumnGroup(columnId, columnId));
                 if (lookupConstraints.isGroupColumn()) {
-                    if (groupOp.getGroupFunctions().size() == 1) {
-                        GroupFunction groupFunction = new GroupFunction(groupOp.getColumnGroup().getSourceId(), null, null);
-                        groupOp.getGroupFunctions().add(0, groupFunction);
-                    } else {
-                        GroupFunction groupFunction = groupOp.getGroupFunctions().get(0);
-                        groupFunction.setSourceId(groupOp.getColumnGroup().getSourceId());
-                        groupFunction.setColumnId(null);
-                        groupFunction.setFunction(null);
+                    if (groupOp.getGroupFunctions().size() > 1) {
+                        groupOp.getGroupFunctions().remove(0);
                     }
+                    GroupFunction groupFunction = new GroupFunction(columnId, columnId, null);
+                    groupOp.getGroupFunctions().add(0, groupFunction);
+
                 }
             }
             // Notify listener


### PR DESCRIPTION
Currently, the SQL data set provider is certified against the following databases:

MySQL 5.5
Postgres 9.2
H2 1.3.168+
Oracle 12c and 11gR2
IBM DB2 9.7 and 10.5
Sybase ASE 15.7

Community is asking for supporting MonetDB which is also an SQL compliant database. The version to support is latest 11.21.5