### PR TITLE
webapp: remove GWT permutations for IE10 and older

### DIFF
--- a/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
+++ b/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
@@ -25,6 +25,7 @@
   <extend-property name="locale" values="de"/>
   <extend-property name="locale" values="ru"/>
 
-  <!-- We don't need to support IE8 or older -->
-  <set-property name="user.agent" value="gecko1_8,safari,ie9,ie10"/>
+  <!-- We don't need to support IE10 or older -->
+  <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
+  <set-property name="user.agent" value="gecko1_8,safari"/>
 </module>


### PR DESCRIPTION
 * only IE11+ is supported