### PR TITLE
Remove log4j deps; modules must not depend on logging impls

### DIFF
--- a/dashbuilder-client/dashbuilder-dataset-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-dataset-client/pom.xml
@@ -84,16 +84,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <scope>provided</scope>

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/pom.xml
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/pom.xml
@@ -33,16 +33,6 @@
     </dependency>
 
     <!--
-    Runtime dependencies
-    -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <!--
     Optional dependencies
     -->
     <dependency>

--- a/dashbuilder-shared/dashbuilder-validations/pom.xml
+++ b/dashbuilder-shared/dashbuilder-validations/pom.xml
@@ -57,16 +57,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-validation</artifactId>
     </dependency>

--- a/dashbuilder-webapp/pom.xml
+++ b/dashbuilder-webapp/pom.xml
@@ -336,6 +336,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Errai -->
 


### PR DESCRIPTION
 * individual modules must not depend on specific logging impls,
   only on SLF4J API. Logging impls are then plugged-in in
   end-user apps