### PR TITLE
Upgrade surefire and failsafe plugins to 2.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.18.1</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>
@@ -171,7 +171,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.18.1</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
Same version as used by KIE projects. I am hoping this could mitigate the intermittent build failures like this one https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/uberfire-extenstions-pullrequests/66/console