### PR TITLE
Exclude log4j and commons-logging where needed + add enforcer rule to…

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
@@ -84,6 +84,17 @@
     <dependency>
       <groupId>io.searchbox</groupId>
       <artifactId>jest</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for the commons-logging removed from io.searchbox:jest -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
     <dependency>

--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -88,6 +88,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.org.apache.httpcomponents.httpclient}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>org.owasp.encoder</groupId>
         <artifactId>encoder</artifactId>
         <version>${version.org.owasp.encoder}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- That parent extends the org.jboss:jboss-parent -->
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
-    <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
+    <!-- Keep in sync with property <version.org.jboss.integration-platform> in dashbuilder-deps -->
     <version>6.0.0.CR31</version>
   </parent>
 
@@ -107,6 +107,30 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-unwanted-logging-deps</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <phase>validate</phase>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <!-- In case of transitive dependency, exclude it and use jcl-over-slf4j instead -->
+                      <exclude>commons-logging:commons-log*</exclude>
+                      <!-- In case of transitive dependency, exclude it and use log4j-over-slf4j instead -->
+                      <exclude>log4j:log4j</exclude>
+                    </excludes>
+                  </bannedDependencies>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
… ban unwnated logging deps

 * both commons-logging and log4j should not be used. Dashbuilder depends on SLF4J for logging,
   so all other logging frameworks need to be excluded and replaced by the appropriate
   SLF4J logging bridges (e.g. jcl-over-slf4j and log4j-over-slf4j)

 * the enforcer rule makes sure that we catch these violations early, before they
   are even introduced. Solution is to exclude these unwanted (transitive) deps and
   depend explicitely on the logging bridge