### PR TITLE
DASHBUILDE-88: Dataset columns are case sensitive (0.4.x)

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-core/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-core/pom.xml
@@ -71,12 +71,6 @@
     <!-- Unit testing -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetColumnTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetColumnTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataset;
+
+import java.util.List;
+
+import org.dashbuilder.DataSetCore;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.dashbuilder.dataset.ExpenseReportsData.*;
+import static org.junit.Assert.*;
+
+public class DataSetColumnTest {
+
+    public static final String EXPENSE_REPORTS = "expense_reports";
+
+    DataSetManager dataSetManager = DataSetCore.get().getDataSetManager();
+
+    @Before
+    public void setUp() throws Exception {
+        DataSet dataSet = ExpenseReportsData.INSTANCE.toDataSet();
+        dataSet.setUUID(EXPENSE_REPORTS);
+        dataSetManager.registerDataSet(dataSet);
+    }
+
+    @Test
+    public void testDataSetLookupColumns() throws Exception {
+        DataSet result = dataSetManager.lookupDataSet(
+                DataSetLookupFactory.newDataSetLookupBuilder()
+                        .dataset(DataSetGroupTest.EXPENSE_REPORTS)
+                        .column(COLUMN_CITY, "City")
+                        .column(COLUMN_DEPARTMENT, "Department")
+                        .column(COLUMN_EMPLOYEE, "Employee")
+                        .column(COLUMN_AMOUNT, "Amount")
+                        .buildLookup());
+
+        assertEquals(result.getRowCount(), 50);
+        assertEquals(result.getColumnByIndex(0).getId(), "City");
+        assertEquals(result.getColumnByIndex(1).getId(), "Department");
+        assertEquals(result.getColumnByIndex(2).getId(), "Employee");
+        assertEquals(result.getColumnByIndex(3).getId(), "Amount");
+
+        assertEquals(result.getColumnByIndex(0).getColumnType(), ColumnType.LABEL);
+        assertEquals(result.getColumnByIndex(1).getColumnType(), ColumnType.LABEL);
+        assertEquals(result.getColumnByIndex(2).getColumnType(), ColumnType.LABEL);
+        assertEquals(result.getColumnByIndex(3).getColumnType(), ColumnType.NUMBER);
+
+        assertEquals(result.getValueAt(0, 0), "Barcelona");
+        assertEquals(result.getValueAt(0, 1), "Engineering");
+        assertEquals(result.getValueAt(0, 2), "Roxie Foraker");
+        assertEquals(result.getValueAt(0, 3), 120.35d);
+
+        assertNotNull(result.getColumnById("City"));
+        assertNotNull(result.getColumnById("Department"));
+        assertNotNull(result.getColumnById("Employee"));
+        assertNotNull(result.getColumnById("Amount"));
+
+        assertNotNull(result.getColumnById("CITY"));
+        assertNotNull(result.getColumnById("DEPARTMENT"));
+        assertNotNull(result.getColumnById("EMPLOYEE"));
+        assertNotNull(result.getColumnById("AMOUNT"));
+
+        assertNotNull(result.getColumnById("city"));
+        assertNotNull(result.getColumnById("department"));
+        assertNotNull(result.getColumnById("employee"));
+        assertNotNull(result.getColumnById("amount"));
+    }
+
+    @Test
+    public void testDataSetMetadataColumns() throws Exception {
+        DataSetMetadata result = dataSetManager.getDataSetMetadata(EXPENSE_REPORTS);
+
+        assertEquals(result.getNumberOfColumns(), 6);
+        assertEquals(result.getNumberOfRows(), 50);
+
+        List<String> columnIds = result.getColumnIds();
+        assertEquals(columnIds.size(), 6);
+        
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_ID));
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_CITY));
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_DEPARTMENT));
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_EMPLOYEE));
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_DATE));
+        assertTrue(containsIgnoreCase(columnIds, COLUMN_AMOUNT));
+
+        assertEquals(result.getColumnType("Expenses_id"), ColumnType.NUMBER);
+        assertEquals(result.getColumnType("City"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("Department"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("Employee"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("Creation_date"), ColumnType.DATE);
+        assertEquals(result.getColumnType("Amount"), ColumnType.NUMBER);
+
+        assertEquals(result.getColumnType("expenses_id"), ColumnType.NUMBER);
+        assertEquals(result.getColumnType("city"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("department"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("employee"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("creation_date"), ColumnType.DATE);
+        assertEquals(result.getColumnType("amount"), ColumnType.NUMBER);
+
+        assertEquals(result.getColumnType("EXPENSES_ID"), ColumnType.NUMBER);
+        assertEquals(result.getColumnType("CITY"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("DEPARTMENT"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("EMPLOYEE"), ColumnType.LABEL);
+        assertEquals(result.getColumnType("CREATION_DATE"), ColumnType.DATE);
+        assertEquals(result.getColumnType("AMOUNT"), ColumnType.NUMBER);
+    }
+
+    public boolean containsIgnoreCase(List<String> list, String str) {
+        for (String element : list) {
+            if (element.equalsIgnoreCase(str)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-csv/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-csv/pom.xml
@@ -58,12 +58,6 @@
     <!-- Unit testing -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert-core</artifactId>
       <scope>test</scope>

--- a/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
@@ -155,12 +155,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/README.md
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/README.md
@@ -21,7 +21,7 @@ For instance, to execute the tests under Oracle:
 
         mvn clean install
 
-  (append *-Dorg.slf4j.simpleLogger.log.org.dashbuilder.dataprovider.backend.sql.JDBCUtils=debug*
+  (append *-Dorg.slf4j.simpleLogger.log.org.dashbuilder.dataprovider.sql.JDBCUtils=debug*
    if you want to see the actual SQL logs being executed)
 
      

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -63,6 +63,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
@@ -58,12 +58,6 @@
     <!-- Unit testing -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.dashbuilder</groupId>
       <artifactId>dashbuilder-dataset-api</artifactId>
       <type>test-jar</type>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/backend/sql/SQLTableDataSetLookupTest.java
@@ -15,11 +15,11 @@
  */
 package org.dashbuilder.dataprovider.backend.sql;
 
-import org.dashbuilder.dataset.ColumnType;
 import org.dashbuilder.dataset.DataSet;
-import org.dashbuilder.dataset.DataSetFactory;
+import org.dashbuilder.dataset.DataSetColumnTest;
 import org.dashbuilder.dataset.DataSetFilterTest;
 import org.dashbuilder.dataset.DataSetGroupTest;
+import org.dashbuilder.dataset.DataSetLookupFactory;
 import org.dashbuilder.dataset.DataSetNestedGroupTest;
 import org.dashbuilder.dataset.filter.FilterFactory;
 import org.dashbuilder.dataset.group.DateIntervalType;
@@ -56,7 +56,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
                     .execute();
 
             DataSet result = dataSetManager.lookupDataSet(
-                    DataSetFactory.newDataSetLookupBuilder()
+                    DataSetLookupFactory.newDataSetLookupBuilder()
                             .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                             .filter(equalsTo(ID.getName(), 9999))
                             .buildLookup());
@@ -81,7 +81,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
     public void testDataSetTrim() throws Exception {
 
         DataSet result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
+                DataSetLookupFactory.newDataSetLookupBuilder()
                         .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                         .rowNumber(10)
                         .buildLookup());
@@ -91,7 +91,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         assertThat(result.getValueAt(9, 0)).isEqualTo(10d);
 
         result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
+                DataSetLookupFactory.newDataSetLookupBuilder()
                         .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                         .rowNumber(10)
                         .rowOffset(40)
@@ -102,7 +102,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         assertThat(result.getValueAt(9, 0)).isEqualTo(50d);
 
         result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
+                DataSetLookupFactory.newDataSetLookupBuilder()
                         .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                         .group(DEPT.getName())
                         .column(DEPT.getName())
@@ -115,7 +115,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         assertThat(result.getRowCountNonTrimmed()).isEqualTo(5);
 
         result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
+                DataSetLookupFactory.newDataSetLookupBuilder()
                         .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                         .filter(CITY.getName(), equalsTo("Barcelona"))
                         .rowNumber(3)
@@ -127,35 +127,9 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
     }
 
     @Test
-    public void testDataSetColumns() throws Exception {
-        DataSet result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
-                        .dataset(DataSetGroupTest.EXPENSE_REPORTS)
-                        .column(CITY.getName(), "City")
-                        .column(DEPT.getName(), "Department")
-                        .column(EMPLOYEE.getName(), "Employee")
-                        .column(AMOUNT.getName(), "Amount")
-                        .buildLookup());
-
-        assertThat(result.getRowCount()).isEqualTo(50);
-        assertThat(result.getColumnByIndex(0).getId()).isEqualTo("City");
-        assertThat(result.getColumnByIndex(1).getId()).isEqualTo("Department");
-        assertThat(result.getColumnByIndex(2).getId()).isEqualTo("Employee");
-        assertThat(result.getColumnByIndex(3).getId()).isEqualTo("Amount");
-        assertThat(result.getColumnByIndex(0).getColumnType()).isEqualTo(ColumnType.LABEL);
-        assertThat(result.getColumnByIndex(1).getColumnType()).isEqualTo(ColumnType.LABEL);
-        assertThat(result.getColumnByIndex(2).getColumnType()).isEqualTo(ColumnType.LABEL);
-        assertThat(result.getColumnByIndex(3).getColumnType()).isEqualTo(ColumnType.NUMBER);
-        assertThat(result.getValueAt(0, 0)).isEqualTo("Barcelona");
-        assertThat(result.getValueAt(0, 1)).isEqualTo("Engineering");
-        assertThat(result.getValueAt(0, 2)).isEqualTo("Roxie Foraker");
-        assertThat(result.getValueAt(0, 3)).isEqualTo(120.35d);
-    }
-
-    @Test
     public void testDataSetGroupByHour() throws Exception {
         DataSet result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
+                DataSetLookupFactory.newDataSetLookupBuilder()
                         .dataset(DataSetGroupTest.EXPENSE_REPORTS)
                         .filter(ID.getName(), FilterFactory.OR(
                                 FilterFactory.equalsTo(40),
@@ -166,6 +140,13 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
 
         assertThat(result.getRowCount()).isEqualTo(25);
         assertThat(result.getValueAt(0,0)).isEqualTo("2012-06-12 12");
+    }
+
+    @Test
+    public void testDataSetColumns() throws Exception {
+        DataSetColumnTest subTest = new DataSetColumnTest();
+        subTest.testDataSetLookupColumns();
+        subTest.testDataSetMetadataColumns();
     }
 
     @Test
@@ -225,39 +206,5 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         if (!testSettings.isMySQL() && !testSettings.isSqlServer()&& !testSettings.isSybase()) {
             subTest.testLikeOperatorCaseSensitive();
         }
-    }
-
-    @Test
-    public void testDataSetColumnsByIdIgnoreCase() throws Exception {
-        DataSet result = dataSetManager.lookupDataSet(
-                DataSetFactory.newDataSetLookupBuilder()
-                        .dataset(DataSetGroupTest.EXPENSE_REPORTS)
-                        .column(CITY.getName(), "City")
-                        .column(DEPT.getName(), "Department")
-                        .column(EMPLOYEE.getName(), "Employee")
-                        .column(AMOUNT.getName(), "Amount")
-                        .buildLookup());
-
-        assertThat(result.getRowCount()).isEqualTo(50);
-        assertThat(result.getColumnByIndex(0).getId()).isEqualTo("City");
-        assertThat(result.getColumnByIndex(1).getId()).isEqualTo("Department");
-        assertThat(result.getColumnByIndex(2).getId()).isEqualTo("Employee");
-        assertThat(result.getColumnByIndex(3).getId()).isEqualTo("Amount");
-
-        assertThat(result.getColumnById("City")).isNotNull();
-        assertThat(result.getColumnById("Department")).isNotNull();
-        assertThat(result.getColumnById("Employee")).isNotNull();
-        assertThat(result.getColumnById("Amount")).isNotNull();
-
-        assertThat(result.getColumnById("city")).isNull();
-        assertThat(result.getColumnById("department")).isNull();
-        assertThat(result.getColumnById("employee")).isNull();
-        assertThat(result.getColumnById("amount")).isNull();
-
-        assertThat(result.getColumnByIdIgnoreCase("city")).isNotNull();
-        assertThat(result.getColumnByIdIgnoreCase("department")).isNotNull();
-        assertThat(result.getColumnByIdIgnoreCase("employee")).isNotNull();
-        assertThat(result.getColumnByIdIgnoreCase("amount")).isNotNull();
-
     }
 }

--- a/dashbuilder-backend/pom.xml
+++ b/dashbuilder-backend/pom.xml
@@ -24,4 +24,14 @@
     <module>dashbuilder-services</module>
   </modules>
 
+  <dependencies>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
 </project>

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/DataSetHandlerImpl.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/DataSetHandlerImpl.java
@@ -236,6 +236,9 @@ public class DataSetHandlerImpl implements DataSetHandler {
         if (cg != null && metadata != null) {
             IntervalBuilderLocator intervalBuilderLocator = clientServices.getIntervalBuilderLocator();
             ColumnType columnType = metadata.getColumnType(cg.getSourceId());
+            if (columnType == null) {
+                throw new RuntimeException("Column type not found in data set metadata: " + cg.getSourceId());
+            }
             IntervalBuilder intervalBuilder = intervalBuilderLocator.lookup(columnType, cg.getStrategy());
             Interval target = intervalBuilder.locate(column, row);
 

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSet.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSet.java
@@ -69,11 +69,6 @@ public interface DataSet {
     DataColumn getColumnById(String id);
 
     /**
-     * Get a column by its id with case insensitive matching.
-     */
-    DataColumn getColumnByIdIgnoreCase(String id);
-
-    /**
      * Get a column by its index (starting at 0).
      */
     DataColumn getColumnByIndex(int index);

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetMetadata.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetMetadata.java
@@ -46,6 +46,11 @@ public interface DataSetMetadata {
     String getColumnId(int columnIndex);
 
     /**
+     * Get the column ids
+     */
+    List<String> getColumnIds();
+
+    /**
      * Get the type of the specified column.
      * @param columnIndex The column index (starting at 0).
      */

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/DataSetImpl.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/DataSetImpl.java
@@ -76,18 +76,9 @@ public class DataSetImpl implements DataSet {
 
     public DataColumn getColumnById(String id) {
         for (DataColumn column : columns) {
-            if (column.getId().equals(id)) return column;
-            GroupFunction gf = column.getGroupFunction();
-            if (gf != null && gf.getSourceId() != null && gf.getSourceId().equals(id)) {
+            if (column.getId().equalsIgnoreCase(id)) {
                 return column;
             }
-        }
-        return null;
-    }
-
-    public DataColumn getColumnByIdIgnoreCase(String id) {
-        for (DataColumn column : columns) {
-            if (column.getId().equalsIgnoreCase(id)) return column;
             GroupFunction gf = column.getGroupFunction();
             if (gf != null && gf.getSourceId() != null && gf.getSourceId().equalsIgnoreCase(id)) {
                 return column;
@@ -108,7 +99,7 @@ public class DataSetImpl implements DataSet {
 
     @Override
     public int getColumnIndex( DataColumn dataColumn ) {
-        if (dataColumn == null || "".equals(dataColumn.getId()) ) {
+        if (dataColumn == null || "".equals(dataColumn.getId())) {
             throw new IllegalArgumentException("Wrong column specified.");
         }
         for (int i = 0; i < columns.size(); i++) {
@@ -140,7 +131,7 @@ public class DataSetImpl implements DataSet {
         Iterator<DataColumnImpl> it = columns.iterator();
         while (it.hasNext()) {
             DataColumn column = it.next();
-            if (column.getId().equals(id)) {
+            if (column.getId().equalsIgnoreCase(id)) {
                 it.remove();
             }
         }

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/DataSetMetadataImpl.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/DataSetMetadataImpl.java
@@ -84,13 +84,19 @@ public class DataSetMetadataImpl implements DataSetMetadata {
     }
 
     public ColumnType getColumnType(String columnId) {
-        if (columnId == null) return null;
+        if (columnId == null) {
+            return null;
+        }
         for (int i=0; i<columnIds.size(); i++) {
-            if (columnId.equals(columnIds.get(i))) {
+            if (columnId.equalsIgnoreCase(columnIds.get(i))) {
                 return columnTypes.get(i);
             }
         }
         return null;
+    }
+
+    public List<String> getColumnIds() {
+        return columnIds;
     }
 
     public List<ColumnType> getColumnTypes() {
@@ -121,7 +127,7 @@ public class DataSetMetadataImpl implements DataSetMetadata {
                 return false;
             }
             for (int i=0; i<columnIds.size(); i++) {
-                if (!columnIds.get(i).equals(other.columnIds.get(i))) {
+                if (!columnIds.get(i).equalsIgnoreCase(other.columnIds.get(i))) {
                     return false;
                 }
             }


### PR DESCRIPTION
Fix + test

NOTE: The dashbuilder-dataset-sql-tests have been also executed against all the supported DBs