### PR TITLE
GWT 2.8 upgrade: Add default constructors to Errai CDI beans

### DIFF
--- a/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServices.java
+++ b/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/DataSetClientServices.java
@@ -79,6 +79,9 @@ public class DataSetClientServices {
      */
     private Map<String,DataSetPushHandler> pushRequestMap = new HashMap<String,DataSetPushHandler>();
 
+    public DataSetClientServices() {
+    }
+
     @Inject
     public DataSetClientServices(ClientDataSetManager clientDataSetManager,
                                  AggregateFunctionManager aggregateFunctionManager,

--- a/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/engine/ClientIntervalBuilderDynamicDate.java
+++ b/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/engine/ClientIntervalBuilderDynamicDate.java
@@ -45,6 +45,9 @@ public class ClientIntervalBuilderDynamicDate implements IntervalBuilder {
 
     private ClientDateFormatter dateFormatter;
 
+    public ClientIntervalBuilderDynamicDate() {
+    }
+
     @Inject
     public ClientIntervalBuilderDynamicDate(ClientDateFormatter dateFormatter) {
         this.dateFormatter = dateFormatter;

--- a/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/engine/ClientIntervalBuilderLocator.java
+++ b/dashbuilder-client/dashbuilder-dataset-client/src/main/java/org/dashbuilder/dataset/client/engine/ClientIntervalBuilderLocator.java
@@ -33,6 +33,9 @@ public class ClientIntervalBuilderLocator implements IntervalBuilderLocator {
     ClientIntervalBuilderDynamicDate intervalBuilderDynamicDate;
     IntervalBuilderFixedDate intervalBuilderFixedDate;
 
+    public ClientIntervalBuilderLocator() {
+    }
+
     @Inject
     public ClientIntervalBuilderLocator(IntervalBuilderDynamicLabel intervalBuilderDynamicLabel,
                                         ClientIntervalBuilderDynamicDate intervalBuilderDynamicDate,

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/DisplayerLocator.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/DisplayerLocator.java
@@ -40,6 +40,9 @@ public class DisplayerLocator {
     private ValueFormatterRegistry formatterRegistry;
     private RendererManager rendererManager;
 
+    public DisplayerLocator() {
+    }
+
     @Inject
     public DisplayerLocator(DataSetClientServices clientServices,
                             ClientDataSetManager clientDataSetManager,

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/RendererManager.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/RendererManager.java
@@ -46,6 +46,9 @@ public class RendererManager {
     private Map<DisplayerType, List<RendererLibrary>> renderersByType = new EnumMap<DisplayerType, List<RendererLibrary>>(DisplayerType.class);
     private Map<DisplayerSubType, List<RendererLibrary>> renderersBySubType = new EnumMap<DisplayerSubType, List<RendererLibrary>>(DisplayerSubType.class);
 
+    public RendererManager() {
+    }
+
     @Inject
     public RendererManager(SyncBeanManager beanManager) {
         this.beanManager = beanManager;

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/prototypes/DataSetPrototypes.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/prototypes/DataSetPrototypes.java
@@ -63,6 +63,9 @@ public class DataSetPrototypes {
         return dataSetManager.getDataSet("continentPopulationExt");
     }
 
+    public DataSetPrototypes() {
+    }
+
     @Inject
     public DataSetPrototypes(ClientDataSetManager dataSetManager) {
         this.dataSetManager = dataSetManager;

--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/prototypes/DisplayerPrototypes.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/prototypes/DisplayerPrototypes.java
@@ -37,6 +37,9 @@ public class DisplayerPrototypes {
 
     protected Map<DisplayerType,DisplayerSettings> prototypeMap = new EnumMap<DisplayerType,DisplayerSettings>(DisplayerType.class);
 
+    public DisplayerPrototypes() {
+    }
+
     @Inject
     public DisplayerPrototypes(DataSetPrototypes dataSetPrototypes, UUIDGenerator uuidGenerator) {
         this.dataSetPrototypes = dataSetPrototypes;

--- a/dashbuilder-client/dashbuilder-displayer-screen/src/main/java/org/dashbuilder/displayer/client/PerspectiveCoordinator.java
+++ b/dashbuilder-client/dashbuilder-displayer-screen/src/main/java/org/dashbuilder/displayer/client/PerspectiveCoordinator.java
@@ -43,6 +43,9 @@ public class PerspectiveCoordinator {
      */
     boolean editOn = false;
 
+    public PerspectiveCoordinator() {
+    }
+
     @Inject
     public PerspectiveCoordinator(DisplayerCoordinator coordinator) {
         this.displayerCoordinator = coordinator;

--- a/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/common/LoadingBox.java
+++ b/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/common/LoadingBox.java
@@ -20,6 +20,9 @@ public class LoadingBox {
 
     View view;
 
+    public LoadingBox() {
+    }
+
     @Inject
     public LoadingBox(View view) {
         this.view = view;

--- a/dashbuilder-shared/dashbuilder-validations/src/main/java/org/dashbuilder/validations/dataset/DataSetDefValidator.java
+++ b/dashbuilder-shared/dashbuilder-validations/src/main/java/org/dashbuilder/validations/dataset/DataSetDefValidator.java
@@ -23,6 +23,9 @@ public class DataSetDefValidator extends DashbuilderValidator {
 
     SyncBeanManager beanManager;
 
+    public DataSetDefValidator() {
+    }
+
     @Inject
     public DataSetDefValidator(SyncBeanManager beanManager) {
         this.beanManager = beanManager;


### PR DESCRIPTION
Fixes JS errors like:

16:31:11 SEVERE [LogConfiguration] Exception caught: Exception caught: While creating a proxy for org.dashbuilder.displayer.client.prototypes.DataSetPrototypes an exception was thrown from this constructor: @javax.inject.Inject()  public org.dashbuilder.displayer.client.prototypes.DataSetPrototypes ([org.dashbuilder.dataset.client.ClientDataSetManager])
To fix this problem, add a no-argument public or protected constructor for use in proxying