### PR TITLE
multiple code improvements

### DIFF
--- a/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerSubtypeSelector.java
+++ b/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerSubtypeSelector.java
@@ -75,7 +75,7 @@ public class DisplayerSubtypeSelector implements IsWidget {
         RendererLibrary rendererLibrary = rendererManager.getRendererForType(type);
         if (rendererLibrary != null) {
             List<DisplayerSubType> supportedSubTypes = rendererLibrary.getSupportedSubtypes(type);
-            if (supportedSubTypes != null && supportedSubTypes.size() > 0) {
+            if (supportedSubTypes != null && !supportedSubTypes.isEmpty()) {
                 for (int i = 0; i < supportedSubTypes.size(); i++) {
                     DisplayerSubType subtype = supportedSubTypes.get(i);
 

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetLookupConstraints.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetLookupConstraints.java
@@ -216,9 +216,9 @@ public class DataSetLookupConstraints extends DataSetConstraints<DataSetLookupCo
             ColumnType columnType = metadata.getColumnType(gf.getSourceId());
             if (i < types.length && !columnType.equals(types[i])) {
 
-                boolean isGroupColumn = (columnGroup != null && columnGroup.getSourceId().equals(gf.getSourceId()));
-                boolean isGroupLabel = (isGroupColumn && types[i].equals(ColumnType.LABEL));
-                boolean isFunctionColumn = (gf.getFunction() != null && !columnType.equals(ColumnType.NUMBER));
+                boolean isGroupColumn = columnGroup != null && columnGroup.getSourceId().equals(gf.getSourceId());
+                boolean isGroupLabel = isGroupColumn && types[i].equals(ColumnType.LABEL);
+                boolean isFunctionColumn = gf.getFunction() != null && !columnType.equals(ColumnType.NUMBER);
 
                 if (!isGroupLabel && !isFunctionColumn) {
                     return createValidationError(ERROR_COLUMN_TYPE, i, types[i], columnType);

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeInstant.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/date/TimeInstant.java
@@ -208,8 +208,8 @@ public class TimeInstant {
             int month = startDate.getMonth();
             int firstMonth = firstMonthOfYear.getIndex()-1;
             int yearInc =  0;
-            if (TimeMode.BEGIN.equals(timeMode)) yearInc = (month < firstMonth ? -1 : 0);
-            else yearInc = (month < firstMonth ? 0 : 1);
+            if (TimeMode.BEGIN.equals(timeMode)) yearInc = month < firstMonth ? -1 : 0;
+            else yearInc = month < firstMonth ? 0 : 1;
 
             startDate.setYear(startDate.getYear() + yearInc);
             startDate.setMonth(firstMonth);
@@ -224,7 +224,7 @@ public class TimeInstant {
             int yearInc = 0;
             int monthInc = 3;
             if (TimeMode.BEGIN.equals(timeMode)) {
-                yearInc = (firstMonth>month ? -1 : 0);
+                yearInc = firstMonth>month ? -1 : 0;
                 monthInc = 0;
             }
             startDate.setYear(startDate.getYear() + yearInc);

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/MemSizeEstimator.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/impl/MemSizeEstimator.java
@@ -51,7 +51,7 @@ public class MemSizeEstimator {
 
     public static int sizeOf(Class clazz) {
         Integer size = sizeOfMap.get(clazz);
-        return (size != null ? size : 0);
+        return size != null ? size : 0;
     }
 
     public static int sizeOf(Object o) {

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/json/DataSetDefJSONMarshaller.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/json/DataSetDefJSONMarshaller.java
@@ -398,16 +398,16 @@ public class DataSetDefJSONMarshaller {
 
         // Specific provider.
         if (dataSetDef instanceof BeanDataSetDef) {
-            toJsonObject(((BeanDataSetDef)dataSetDef), json);
+            toJsonObject((BeanDataSetDef)dataSetDef, json);
         } 
         else if (dataSetDef instanceof CSVDataSetDef) {
-            toJsonObject(((CSVDataSetDef)dataSetDef), json);
+            toJsonObject((CSVDataSetDef)dataSetDef, json);
         } 
         else if (dataSetDef instanceof SQLDataSetDef) {
-            toJsonObject(((SQLDataSetDef)dataSetDef), json);
+            toJsonObject((SQLDataSetDef)dataSetDef, json);
         } 
         else if (dataSetDef instanceof ElasticSearchDataSetDef) {
-            toJsonObject(((ElasticSearchDataSetDef)dataSetDef), json);
+            toJsonObject((ElasticSearchDataSetDef)dataSetDef, json);
         }
         
         // Data columns.

--- a/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/json/DataSetLookupJSONMarshaller.java
+++ b/dashbuilder-shared/dashbuilder-dataset-api/src/main/java/org/dashbuilder/dataset/json/DataSetLookupJSONMarshaller.java
@@ -144,7 +144,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatFilterOperations(List<DataSetFilter> filterOps) throws JsonException {
-        if ( filterOps.size() == 0 ) {
+        if ( filterOps.isEmpty() ) {
             return null;
         }
         // There should be only one DataSetFilter
@@ -190,7 +190,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatGroupOperations(List<DataSetGroup> groupOps) throws JsonException {
-        if (groupOps.size() == 0) {
+        if (groupOps.isEmpty()) {
             return null;
         }
         JsonArray groupOpsJsonArray = Json.createArray();
@@ -231,7 +231,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatGroupFunctions(List<GroupFunction> groupFunctions) throws JsonException {
-        if (groupFunctions.size() == 0) {
+        if (groupFunctions.isEmpty()) {
             return null;
         }
         JsonArray groupOpsJsonArray = Json.createArray();
@@ -254,7 +254,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatSelectedIntervals(List<Interval> selectedIntervalList) throws JsonException {
-        if (selectedIntervalList.size() == 0) {
+        if (selectedIntervalList.isEmpty()) {
             return null;
         }
         JsonArray selectedIntervalNamesJsonArray = Json.createArray();
@@ -285,7 +285,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatSortOperations(List<DataSetSort> sortOps) throws JsonException {
-        if (sortOps.size() == 0) {
+        if (sortOps.isEmpty()) {
             return null;
         }
         // There should be only one DataSetFilter
@@ -293,7 +293,7 @@ public class DataSetLookupJSONMarshaller {
     }
 
     public JsonArray formatColumnSorts(List<ColumnSort> columnSorts) throws JsonException {
-        if (columnSorts.size() == 0) {
+        if (columnSorts.isEmpty()) {
             return null;
         }
         JsonArray columnSortsJsonArray = Json.createArray();

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/comparator/ComparatorUtils.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/comparator/ComparatorUtils.java
@@ -100,8 +100,8 @@ public class ComparatorUtils {
         if (o1 == null && o2 != null) comp = -1;
         else if (o1 != null && o2 == null) comp = 1;
         else if (o1 == null && o2 == null) comp = 0;
-        else if (o1.size() == 0 && o2.size() > 0) comp = -1;
-        else if (o1.size() > 0 && o2.size() == 0) comp = 1;
+        else if (o1.isEmpty() && !o2.isEmpty()) comp = -1;
+        else if (!o1.isEmpty() && o2.isEmpty()) comp = 1;
         else {
             // Compare o1 elements vs o2
             int o1comp = 0;
@@ -142,8 +142,8 @@ public class ComparatorUtils {
         // Compare
         int comp = 0;
         if (obj == null && col == null) comp = 0;
-        else if (obj == null && col != null && col.size() > 0) comp = -1;
-        else if (obj != null && (col == null || col.size() == 0)) comp = 1;
+        else if (obj == null && col != null && !col.isEmpty()) comp = -1;
+        else if (obj != null && (col == null || col.isEmpty())) comp = 1;
         else {
             // Both collections have the same size.
             Iterator it = col.iterator();

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/sort/DataSetRowComparator.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/sort/DataSetRowComparator.java
@@ -39,7 +39,7 @@ public class DataSetRowComparator implements Comparator<Integer> {
 
     public int compare(Integer row1, Integer row2) {
         // Check criteria.
-        if (columns.size() == 0) return 0;
+        if (columns.isEmpty()) return 0;
 
         // Objects must be not null arrays.
         if (row1 == null && row2 != null) return -1;

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConfigurationImpl.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConfigurationImpl.java
@@ -161,7 +161,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 				}
 				else {
 					List<ValidationProvider<?>> providers = providerResolver.getValidationProviders();
-					assert providers.size() != 0; // I run therefore I am
+					assert !providers.isEmpty(); // I run therefore I am
 					factory = providers.get( 0 ).buildValidatorFactory( this );
 				}
 			}

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConstraintTree.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConstraintTree.java
@@ -113,7 +113,7 @@ public class ConstraintTree<A extends Annotation> {
 		// main constraint. We already have to generate the message here, since the composing constraints might
 		// not have its own ConstraintValidator.
 		// Also we want to leave it open to the final ConstraintValidator to generate a custom message. 
-		if ( constraintViolations.size() > 0 && reportAsSingleViolation() ) {
+		if ( !constraintViolations.isEmpty() && reportAsSingleViolation() ) {
 			constraintViolations.clear();
 			final String message = ( String ) getDescriptor().getAttributes().get( "message" );
 			MessageAndPath messageAndPath = new MessageAndPath( message, valueContext.getPropertyPath() );
@@ -230,7 +230,7 @@ public class ConstraintTree<A extends Annotation> {
 	}
 
 	private void verifyResolveWasUnique(Type valueClass, List<Type> assignableClasses) {
-		if ( assignableClasses.size() == 0 ) {
+		if ( assignableClasses.isEmpty() ) {
 			String className = valueClass.toString();
 			if ( valueClass instanceof Class ) {
 				Class<?> clazz = ( Class<?> ) valueClass;
@@ -274,7 +274,7 @@ public class ConstraintTree<A extends Annotation> {
 	 * which are handled by at least one of the  validators for the specified constraint.
 	 */
 	private void resolveAssignableTypes(List<Type> assignableTypes) {
-		if ( assignableTypes.size() == 0 || assignableTypes.size() == 1 ) {
+		if ( assignableTypes.isEmpty() || assignableTypes.size() == 1 ) {
 			return;
 		}
 
@@ -291,7 +291,7 @@ public class ConstraintTree<A extends Annotation> {
 				}
 			}
 			assignableTypes.removeAll( typesToRemove );
-		} while ( typesToRemove.size() > 0 );
+		} while ( !typesToRemove.isEmpty() );
 	}
 
 	private <V> void initializeConstraint

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConstraintValidatorContextImpl.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ConstraintValidatorContextImpl.java
@@ -56,7 +56,7 @@ public class ConstraintValidatorContextImpl implements ConstraintValidatorContex
 	}
 
 	public List<MessageAndPath> getMessageAndPathList() {
-		if ( defaultDisabled && messageAndPaths.size() == 0 ) {
+		if ( defaultDisabled && messageAndPaths.isEmpty() ) {
 			throw new ValidationException(
 					"At least one custom message must be created if the default error message gets disabled."
 			);

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/PathImpl.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/PathImpl.java
@@ -112,7 +112,7 @@ public class PathImpl implements Path, Serializable {
 	}
 
 	public Node removeLeafNode() {
-		if ( nodeList.size() == 0 ) {
+		if ( nodeList.isEmpty() ) {
 			throw new IllegalStateException( "No nodes in path!" );
 		}
 		if ( nodeList.size() == 1 ) {
@@ -122,7 +122,7 @@ public class PathImpl implements Path, Serializable {
 	}
 
 	public NodeImpl getLeafNode() {
-		if ( nodeList.size() == 0 ) {
+		if ( nodeList.isEmpty() ) {
 			throw new IllegalStateException( "No nodes in path!" );
 		}
 		return ( NodeImpl ) nodeList.get( nodeList.size() - 1 );

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ValidatorImpl.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/ValidatorImpl.java
@@ -476,7 +476,7 @@ public class ValidatorImpl implements Validator {
 			throw new IllegalArgumentException( "Invalid property path." );
 		}
 
-		if ( metaConstraints.size() == 0 ) {
+		if ( metaConstraints.isEmpty() ) {
 			return;
 		}
 
@@ -570,7 +570,7 @@ public class ValidatorImpl implements Validator {
 		Set<MetaConstraint<T, ?>> metaConstraints = new HashSet<MetaConstraint<T, ?>>();
 		collectMetaConstraintsForPath( beanType, null, propertyPath.iterator(), metaConstraints );
 
-		if ( metaConstraints.size() == 0 ) {
+		if ( metaConstraints.isEmpty() ) {
 			return;
 		}
 

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/groups/GroupChain.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/groups/GroupChain.java
@@ -58,7 +58,7 @@ public final class GroupChain {
 	}
 
 	public void insertSequence(List<Group> groups) {
-		if ( groups == null || groups.size() == 0 ) {
+		if ( groups == null || groups.isEmpty() ) {
 			return;
 		}
 

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/groups/GroupChainGenerator.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/engine/groups/GroupChainGenerator.java
@@ -43,7 +43,7 @@ public class GroupChainGenerator {
 	 * @return an instance of {@code GroupChain} defining the order in which validation has to occur.
 	 */
 	public GroupChain getGroupChainFor(Collection<Class<?>> groups) {
-		if ( groups == null || groups.size() == 0 ) {
+		if ( groups == null || groups.isEmpty() ) {
 			throw new IllegalArgumentException( "At least one groups has to be specified." );
 		}
 

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/ConstraintHelper.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/ConstraintHelper.java
@@ -161,7 +161,7 @@ public class ConstraintHelper {
 	public List<Class<? extends ConstraintValidator<? extends Annotation, ?>>> getBuiltInConstraints(Class<? extends Annotation> annotationClass) {
 		final List<Class<? extends ConstraintValidator<?, ?>>> builtInList = builtinConstraints.get( annotationClass );
 
-		if ( builtInList == null || builtInList.size() == 0 ) {
+		if ( builtInList == null || builtInList.isEmpty() ) {
 			throw new ValidationException( "Unable to find constraints for  " + annotationClass );
 		}
 

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/ElementDescriptorImpl.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/ElementDescriptorImpl.java
@@ -56,7 +56,7 @@ public class ElementDescriptorImpl implements ElementDescriptor {
 	}
 
 	public boolean hasConstraints() {
-		return constraintDescriptors.size() != 0;
+		return !constraintDescriptors.isEmpty();
 	}
 
 	public Class<?> getElementClass() {
@@ -134,7 +134,7 @@ public class ElementDescriptorImpl implements ElementDescriptor {
 		}
 
 		public boolean hasConstraints() {
-			return getConstraintDescriptors().size() != 0;
+			return !getConstraintDescriptors().isEmpty();
 		}
 
 		private void addMatchingDescriptorsForGroup(Class<?> group, Set<ConstraintDescriptor<?>> matchingDescriptors) {

--- a/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/MetaConstraint.java
+++ b/dashbuilder-shared/dashbuilder-hibernate-validator/src/main/java/org/hibernate/validator/metadata/MetaConstraint.java
@@ -121,7 +121,7 @@ public class MetaConstraint<T, A extends Annotation> {
 		constraintTree.validateConstraints(
 				typeOfAnnotatedElement(), executionContext, valueContext, constraintViolations
 		);
-		if ( constraintViolations.size() > 0 ) {
+		if ( !constraintViolations.isEmpty() ) {
 			executionContext.addConstraintFailures( constraintViolations );
 			return false;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava