### PR TITLE
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

### DIFF
--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/AverageFunction.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/AverageFunction.java
@@ -35,8 +35,7 @@ public class AverageFunction extends SumFunction {
     public double aggregate(List values) {
         if (values == null || values.isEmpty()) return 0;
         double average = super.aggregate(values) / values.size();
-        double ret = round(average, precission);
-        return ret;
+        return round(average, precission);
     }
 
     public double aggregate(List values, List<Integer> rows) {
@@ -45,8 +44,7 @@ public class AverageFunction extends SumFunction {
         if (values == null || values.isEmpty()) return 0;
 
         double average = super.aggregate(values, rows) / rows.size();
-        double ret = round(average, precission);
-        return ret;
+        return round(average, precission);
     }
 
 }

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/MaxFunction.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/MaxFunction.java
@@ -46,8 +46,7 @@ public class MaxFunction extends AbstractFunction {
             if (max == null || n.doubleValue() > max.doubleValue()) max = n;
         }
         if (max == null) return 0;
-        double ret = round(max.doubleValue(), precission);
-        return ret;
+        return round(max.doubleValue(), precission);
     }
 
     public double aggregate(List values, List<Integer> rows) {
@@ -63,7 +62,6 @@ public class MaxFunction extends AbstractFunction {
             if (max == null || n.doubleValue() > max.doubleValue()) max = n;
         }
         if (max == null) return 0;
-        double ret = round(max.doubleValue(), precission);
-        return ret;
+        return round(max.doubleValue(), precission);
     }
 }

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/MinFunction.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/MinFunction.java
@@ -47,8 +47,7 @@ public class MinFunction extends AbstractFunction {
         }
         // Adjust to the specified precision.
         if (min == null) return 0;
-        double ret = round(min.doubleValue(), precission);
-        return ret;
+        return round(min.doubleValue(), precission);
     }
 
     public double aggregate(List values, List<Integer> rows) {
@@ -65,7 +64,6 @@ public class MinFunction extends AbstractFunction {
         }
         // Adjust to the specified precision.
         if (min == null) return 0;
-        double ret = round(min.doubleValue(), precission);
-        return ret;
+        return round(min.doubleValue(), precission);
     }
 }

--- a/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/SumFunction.java
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/src/main/java/org/dashbuilder/dataset/engine/function/SumFunction.java
@@ -45,8 +45,7 @@ public class SumFunction extends AbstractFunction {
             if (n == null) continue;
             sum += n.doubleValue();
         }
-        double ret = round(sum, precission);
-        return ret;
+        return round(sum, precission);
     }
 
     public double aggregate(List values, List<Integer> rows) {
@@ -61,7 +60,6 @@ public class SumFunction extends AbstractFunction {
             if (n == null) continue;
             sum += n.doubleValue();
         }
-        double ret = round(sum, precission);
-        return ret;
+        return round(sum, precission);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
Please let me know if you have any questions.
George Kankava