### PR TITLE
Ban old 'javassist:javassist' + remove no longer needed exclusions

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -120,12 +120,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-backend/dashbuilder-services/pom.xml
+++ b/dashbuilder-backend/dashbuilder-services/pom.xml
@@ -73,13 +73,6 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
-      <exclusions>
-        <exclusion>
-          <!-- Collides with org.javassist:javassist -->
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -121,12 +114,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-common-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-common-client/pom.xml
@@ -72,12 +72,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-dataset-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-dataset-client/pom.xml
@@ -55,12 +55,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
+++ b/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
@@ -40,12 +40,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-displayer-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-client/pom.xml
@@ -45,12 +45,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     
     <dependency>

--- a/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
@@ -40,12 +40,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
@@ -35,12 +35,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
@@ -67,12 +67,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-client/dashbuilder-widgets/pom.xml
+++ b/dashbuilder-client/dashbuilder-widgets/pom.xml
@@ -55,12 +55,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder-shared/dashbuilder-services-api/pom.xml
+++ b/dashbuilder-shared/dashbuilder-services-api/pom.xml
@@ -34,12 +34,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
           </dependencies>
           <executions>
             <execution>
-              <id>ban-unwanted-logging-deps</id>
+              <id>ban-unwanted-deps</id>
               <goals>
                 <goal>enforce</goal>
               </goals>
@@ -129,10 +129,14 @@
                 <rules>
                   <bannedDependencies>
                     <excludes>
+                      <!-- Ban unwanted logging deps -->
                       <!-- In case of transitive dependency, exclude it and use jcl-over-slf4j instead -->
                       <exclude>commons-logging:commons-log*</exclude>
                       <!-- In case of transitive dependency, exclude it and use log4j-over-slf4j instead -->
                       <exclude>log4j:log4j</exclude>
+
+                      <!-- Ban 'javassist:javassist' in favor of 'org.javassist:javassist' -->
+                      <exclude>javassist:javassist</exclude>
                     </excludes>
                   </bannedDependencies>
                 </rules>


### PR DESCRIPTION
The exclusion is done directly in UberFire (actually in Errai), so these are no longer needed. The enforcer rule makes sure to fail the build in case javassist:javassist would creep up again (which really should not as we need to use org.javassist:javassist).