### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/expenses/ExpensesDashboard.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/expenses/ExpensesDashboard.java
@@ -66,6 +66,12 @@ public class ExpensesDashboard extends Composite implements GalleryWidget {
     DisplayerCoordinator displayerCoordinator;
     DisplayerLocator displayerLocator;
 
+    @Inject
+    public ExpensesDashboard(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
+        this.displayerCoordinator = displayerCoordinator;
+        this.displayerLocator = displayerLocator;
+    }
+
     @Override
     public String getTitle() {
         return AppConstants.INSTANCE.expensesdb_title();
@@ -79,12 +85,6 @@ public class ExpensesDashboard extends Composite implements GalleryWidget {
     @Override
     public boolean feedsFrom(String dataSetId) {
         return EXPENSES.equals(dataSetId);
-    }
-
-    @Inject
-    public ExpensesDashboard(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
-        this.displayerCoordinator = displayerCoordinator;
-        this.displayerLocator = displayerLocator;
     }
 
     @PostConstruct

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/metrics/ClusterMetricsDashboard.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/metrics/ClusterMetricsDashboard.java
@@ -64,6 +64,11 @@ import static org.dashbuilder.dataset.filter.FilterFactory.*;
 @Dependent
 public class ClusterMetricsDashboard extends Composite implements GalleryWidget {
 
+    public static final String CPU = AppConstants.INSTANCE.metrics_cluster_metricselector_cpu();
+    public static final String MEMORY = AppConstants.INSTANCE.metrics_cluster_metricselector_mem();
+    public static final String DISK = AppConstants.INSTANCE.metrics_cluster_metricselector_disk();
+    public static final String NETWORK = AppConstants.INSTANCE.metrics_cluster_metricselector_netw();
+
     interface Binder extends UiBinder<Widget, ClusterMetricsDashboard> {}
     private static final Binder uiBinder = GWT.create(Binder.class);
 
@@ -116,6 +121,12 @@ public class ClusterMetricsDashboard extends Composite implements GalleryWidget 
         }
     };
 
+    @Inject
+    public ClusterMetricsDashboard(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
+        this.displayerCoordinator = displayerCoordinator;
+        this.displayerLocator = displayerLocator;
+    }
+
     @Override
     public String getTitle() {
         return AppConstants.INSTANCE.metrics_cluster_title();
@@ -155,17 +166,6 @@ public class ClusterMetricsDashboard extends Composite implements GalleryWidget 
             this.tableVisible = tableVisible;
             this.units = units;
         }
-    }
-
-    public static final String CPU = AppConstants.INSTANCE.metrics_cluster_metricselector_cpu();
-    public static final String MEMORY = AppConstants.INSTANCE.metrics_cluster_metricselector_mem();
-    public static final String DISK = AppConstants.INSTANCE.metrics_cluster_metricselector_disk();
-    public static final String NETWORK = AppConstants.INSTANCE.metrics_cluster_metricselector_netw();
-
-    @Inject
-    public ClusterMetricsDashboard(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
-        this.displayerCoordinator = displayerCoordinator;
-        this.displayerLocator = displayerLocator;
     }
 
     @PostConstruct

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesDistributionByCountry.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesDistributionByCountry.java
@@ -58,6 +58,12 @@ public class SalesDistributionByCountry extends Composite implements GalleryWidg
     DisplayerCoordinator displayerCoordinator;
     DisplayerLocator displayerLocator;
 
+    @Inject
+    public SalesDistributionByCountry(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
+        this.displayerCoordinator = displayerCoordinator;
+        this.displayerLocator = displayerLocator;
+    }
+
     @Override
     public String getTitle() {
         return AppConstants.INSTANCE.sales_bycountry_title();
@@ -76,12 +82,6 @@ public class SalesDistributionByCountry extends Composite implements GalleryWidg
     @Override
     public void redrawAll() {
         displayerCoordinator.redrawAll();
-    }
-
-    @Inject
-    public SalesDistributionByCountry(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
-        this.displayerCoordinator = displayerCoordinator;
-        this.displayerLocator = displayerLocator;
     }
 
     @PostConstruct

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesExpectedByDate.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesExpectedByDate.java
@@ -78,6 +78,12 @@ public class SalesExpectedByDate extends Composite implements GalleryWidget {
     DisplayerCoordinator displayerCoordinator;
     DisplayerLocator displayerLocator;
 
+    @Inject
+    public SalesExpectedByDate(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
+        this.displayerCoordinator = displayerCoordinator;
+        this.displayerLocator = displayerLocator;
+    }
+
     @Override
     public String getTitle() {
         return AppConstants.INSTANCE.sales_bydate_title();
@@ -96,12 +102,6 @@ public class SalesExpectedByDate extends Composite implements GalleryWidget {
     @Override
     public void redrawAll() {
         displayerCoordinator.redrawAll();
-    }
-
-    @Inject
-    public SalesExpectedByDate(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
-        this.displayerCoordinator = displayerCoordinator;
-        this.displayerLocator = displayerLocator;
     }
 
     @PostConstruct

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesGoals.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesGoals.java
@@ -64,26 +64,6 @@ public class SalesGoals extends Composite implements GalleryWidget {
     DisplayerCoordinator displayerCoordinator;
     DisplayerLocator displayerLocator;
 
-    @Override
-    public String getTitle() {
-        return AppConstants.INSTANCE.sales_goals_title();
-    }
-
-    @Override
-    public void onClose() {
-        displayerCoordinator.closeAll();
-    }
-
-    @Override
-    public boolean feedsFrom(String dataSetId) {
-        return SALES_OPPS.equals(dataSetId);
-    }
-
-    @Override
-    public void redrawAll() {
-        displayerCoordinator.redrawAll();
-    }
-
     @Inject
     public SalesGoals(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
         this.displayerCoordinator = displayerCoordinator;
@@ -175,5 +155,25 @@ public class SalesGoals extends Composite implements GalleryWidget {
 
         // Draw the charts
         displayerCoordinator.drawAll();
+    }
+
+    @Override
+    public String getTitle() {
+        return AppConstants.INSTANCE.sales_goals_title();
+    }
+
+    @Override
+    public void onClose() {
+        displayerCoordinator.closeAll();
+    }
+
+    @Override
+    public boolean feedsFrom(String dataSetId) {
+        return SALES_OPPS.equals(dataSetId);
+    }
+
+    @Override
+    public void redrawAll() {
+        displayerCoordinator.redrawAll();
     }
 }

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesTableReports.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/sales/widgets/SalesTableReports.java
@@ -64,6 +64,12 @@ public class SalesTableReports extends Composite implements GalleryWidget {
     DisplayerCoordinator displayerCoordinator;
     DisplayerLocator displayerLocator;
 
+    @Inject
+    public SalesTableReports(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
+        this.displayerCoordinator = displayerCoordinator;
+        this.displayerLocator = displayerLocator;
+    }
+
     @Override
     public String getTitle() {
         return AppConstants.INSTANCE.sales_tablereports_title();
@@ -82,12 +88,6 @@ public class SalesTableReports extends Composite implements GalleryWidget {
     @Override
     public void redrawAll() {
         displayerCoordinator.redrawAll();
-    }
-
-    @Inject
-    public SalesTableReports(DisplayerCoordinator displayerCoordinator, DisplayerLocator displayerLocator) {
-        this.displayerCoordinator = displayerCoordinator;
-        this.displayerLocator = displayerLocator;
     }
 
     @PostConstruct


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava