### PR TITLE
Multiple code improvements: squid:S1854, squid:S1213

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-core/src/main/java/org/dashbuilder/dataset/DataSetDefDeployer.java
+++ b/dashbuilder-backend/dashbuilder-dataset-core/src/main/java/org/dashbuilder/dataset/DataSetDefDeployer.java
@@ -40,6 +40,18 @@ public class DataSetDefDeployer {
     protected Thread watcherThread;
     protected DataSetDefJSONMarshaller jsonMarshaller = DataSetDefJSONMarshaller.get();
 
+    FilenameFilter _deployFilter = new FilenameFilter() {
+        public boolean accept(File dir, String name) {
+            return name.endsWith(".deploy");
+        }
+    };
+
+    FilenameFilter _undeployFilter = new FilenameFilter() {
+        public boolean accept(File dir, String name) {
+            return name.endsWith(".undeploy");
+        }
+    };
+
     public DataSetDefDeployer() {
     }
 
@@ -192,18 +204,6 @@ public class DataSetDefDeployer {
             }
         }
     }
-
-    FilenameFilter _deployFilter = new FilenameFilter() {
-        public boolean accept(File dir, String name) {
-            return name.endsWith(".deploy");
-        }
-    };
-
-    FilenameFilter _undeployFilter = new FilenameFilter() {
-        public boolean accept(File dir, String name) {
-            return name.endsWith(".undeploy");
-        }
-    };
 
     public File getCSVFile(CSVDataSetDef def) throws Exception {
         String path = def.getFilePath();

--- a/dashbuilder-backend/dashbuilder-dataset-core/src/main/java/org/dashbuilder/dataset/IntervalBuilderDynamicDate.java
+++ b/dashbuilder-backend/dashbuilder-dataset-core/src/main/java/org/dashbuilder/dataset/IntervalBuilderDynamicDate.java
@@ -43,6 +43,8 @@ import static org.dashbuilder.dataset.group.DateIntervalType.*;
  */
 public class IntervalBuilderDynamicDate implements IntervalBuilder {
 
+    private static SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy hh:mm:ss");
+
     public IntervalList build(DataSetHandler handler, ColumnGroup columnGroup) {
         IntervalDateRangeList results = new IntervalDateRangeList(columnGroup);
         DataSet dataSet = handler.getDataSet();
@@ -317,8 +319,6 @@ public class IntervalBuilderDynamicDate implements IntervalBuilder {
         // Build & return the selected interval
         return new IntervalDateRange(intervalIndex, intervalType, intervalMinDate, intervalMaxDate);
     }
-
-    private static SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy hh:mm:ss");
 
     /**
      * A list containing date range intervals.

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/backend/command/CommandServer.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/backend/command/CommandServer.java
@@ -59,7 +59,7 @@ public class CommandServer implements Runnable {
             Socket clientSocket = serverSocket.accept();
             PrintWriter out = new PrintWriter(clientSocket.getOutputStream(), true);
             BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
-            String commandStr = null;
+            String commandStr;
             while ((commandStr = in.readLine()) != null) {
                 commandEvent.fire(new CommandEvent(commandStr));
                 out.println(">>> " + commandStr + " [OK]");

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/navbar/LogoWidgetView.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/navbar/LogoWidgetView.java
@@ -56,7 +56,7 @@ public class LogoWidgetView
             }
         } );
         try {
-            final Request r = rb.send();
+            rb.send();
         } catch ( RequestException re ) {
             container.setWidget( new Label( AppConstants.INSTANCE.logoBannerError() ) );
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid%3AS1854
https://dev.eclipse.org/sonar/rules/show/squid%3AS1213
Please let me know if you have any questions.
George Kankava