### PR TITLE
Update SingletonBeanDef usage to match upstream API change.

### DIFF
--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/dashboard/DashboardManager.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/dashboard/DashboardManager.java
@@ -104,7 +104,6 @@ public class DashboardManager {
                                        PerspectiveActivity.class,
                                        new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) ),
                                        id,
-                                       true,
                                        true );
         beanManager.registerBean( beanDef );
         activityBeansCache.addNewPerspectiveActivity(beanManager.lookupBeans(id).iterator().next());


### PR DESCRIPTION
This PR should stay open until @psiroky is able to add Errai to the Jenkins job that tests PRs.

This updates usage of the SyncBeanDef interface updated in [this PR](https://github.com/errai/errai/pull/161). At present the Jenkins job that builds this PR will fail because it does not build the changes from the Errai PR.