### PR TITLE
DASHBUILDE-101: MariaDB support (0.4.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Change log
 * MonetDB support added to the SQL provider.
   (the provider has been tested under the MonetDB 11.21.5 release)
 
+* MariaDB support added to the SQL provider.
+  (the provider has been tested under the MariaDB 10.1.10 release)
+
 * New data set filtering functions "IN" and "NOT IN" 
 
 * Data Set Core API available as an embeddable java library

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/pom.xml
@@ -20,19 +20,19 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-dataset-sql-tests</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>dashbuilder-dataset-sql-tests-mysql</artifactId>
+  <artifactId>dashbuilder-dataset-sql-tests-mariadb</artifactId>
   <packaging>jar</packaging>
 
-  <name>Dashbuilder SQL Tests Mysql</name>
+  <name>Dashbuilder SQL Tests MariaDB</name>
 
   <dependencies>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/java/org/dashbuilder/dataprovider/sql/MariaDbTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/java/org/dashbuilder/dataprovider/sql/MariaDbTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.sql;
+
+import org.junit.Test;
+
+public class MariaDbTest extends SQLTestSuite {
+
+    @Override
+    protected DatabaseTestSettings createTestSettings() {
+        return new MariaDbTestSettings();
+    }
+
+    @Test
+    public void testAll() throws Exception {
+        super.testAll();
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/java/org/dashbuilder/dataprovider/sql/MariaDbTestSettings.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/java/org/dashbuilder/dataprovider/sql/MariaDbTestSettings.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.sql;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dashbuilder.dataset.def.SQLDataSetDef;
+import org.mariadb.jdbc.MariaDbDataSource;
+
+public class MariaDbTestSettings extends DatabaseTestSettings {
+
+    @Override
+    public String getDatabaseType() {
+        return MARIADB;
+    }
+
+    @Override
+    public SQLDataSourceLocator getDataSourceLocator() {
+        return new SQLDataSourceLocator() {
+            public DataSource lookup(SQLDataSetDef def) throws Exception {
+                String server = connectionSettings.getProperty("server");
+                String database = connectionSettings.getProperty("database");
+                String port = connectionSettings.getProperty("port");
+                String user = connectionSettings.getProperty("user");
+                String password = connectionSettings.getProperty("password");
+
+                MariaDbDataSource ds = new MariaDbDataSource();
+                ds.setServerName(server);
+                ds.setDatabaseName(database);
+                ds.setPortNumber(Integer.parseInt(port));
+                if (!StringUtils.isBlank(user)) {
+                    ds.setUser(user);
+                }
+                if (!StringUtils.isBlank(password)) {
+                    ds.setPassword(password);
+                }
+                return ds;
+            }
+        };
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/resources/testdb-mariadb.properties
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-mariadb/src/test/resources/testdb-mariadb.properties
@@ -1,0 +1,7 @@
+server=db-28.rhev-ci-vms.eng.rdu2.redhat.com
+database=dballo19
+port=3306
+user=dballo19
+password=dballo19
+
+

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-postgres/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/dashbuilder-dataset-sql-tests-postgres/pom.xml
@@ -28,21 +28,6 @@
 
   <name>Dashbuilder SQL Tests Postgres</name>
 
-  <properties>
-    <version.org.postgres-driver>9.1-901.jdbc4</version.org.postgres-driver>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>${version.org.postgres-driver}</version>
-        <scope>test</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
 
     <dependency>

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -20,6 +20,7 @@
   <!--modules>
     <module>dashbuilder-dataset-sql-tests-h2</module>
     <module>dashbuilder-dataset-sql-tests-mysql</module>
+    <module>dashbuilder-dataset-sql-tests-mariadb</module>
     <module>dashbuilder-dataset-sql-tests-postgres</module>
     <module>dashbuilder-dataset-sql-tests-oracle</module>
     <module>dashbuilder-dataset-sql-tests-sqlserver</module>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/JDBCUtils.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/JDBCUtils.java
@@ -105,6 +105,9 @@ public class JDBCUtils {
         if (url.contains(":mysql:")) {
             return MYSQL;
         }
+        if (url.contains(":mariadb:")) {
+            return MYSQL;
+        }
         if (url.contains(":postgresql:")) {
             return POSTGRES;
         }

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/DatabaseTestSettings.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/DatabaseTestSettings.java
@@ -31,6 +31,7 @@ public class DatabaseTestSettings {
     public static final String H2MEM = "h2mem";
     public static final String POSTGRES = "postgres";
     public static final String MYSQL = "mysql";
+    public static final String MARIADB = "mariadb";
     public static final String ORACLE = "oracle";
     public static final String DB2 = "db2";
     public static final String SQLSERVER = "sqlserver";
@@ -77,6 +78,10 @@ public class DatabaseTestSettings {
 
     public boolean isMySQL() {
         return MYSQL.equals(getDatabaseType());
+    }
+
+    public boolean isMariaDB() {
+        return MARIADB.equals(getDatabaseType());
     }
 
     public boolean isPostgres() {

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLTableDataSetLookupTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLTableDataSetLookupTest.java
@@ -230,7 +230,7 @@ public class SQLTableDataSetLookupTest extends SQLDataSetTestBase {
         subTest.testNotInOperator();
 
         // Skip this test since MySQL,SQLServer & Sybase are non case sensitive by default
-        if (!testSettings.isMySQL() && !testSettings.isSqlServer()&& !testSettings.isSybase()) {
+        if (!testSettings.isMySQL() && !testSettings.isMariaDB() && !testSettings.isSqlServer()&& !testSettings.isSybase()) {
             subTest.testLikeOperatorCaseSensitive();
         }
     }

--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -35,6 +35,12 @@
     <version.io.searchbox.jest>0.1.3</version.io.searchbox.jest>
     <version.org.apache.lucene>4.10.4</version.org.apache.lucene>
     <version.org.elasticsearch>1.7.1</version.org.elasticsearch>
+
+    <!-- database testing -->
+    <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
+    <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
+    <version.org.postgres-driver>9.1-901.jdbc4</version.org.postgres-driver>
+
     <!-- temporary, should be moved to jboss-ip-bom -->
     <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
   </properties>
@@ -196,6 +202,29 @@
         <groupId>com.ahome-it</groupId>
         <artifactId>lienzo-charts</artifactId>
         <version>${version.com.ahomeit.lienzo.charts}</version>
+      </dependency>
+
+      <!-- Test deps -->
+
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>${version.org.mysql-driver}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${version.org.postgres-driver}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>${version.org.mariadb.jdbc}</version>
+        <scope>test</scope>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Support for MariaDB. 

SQL provider test battery successfully executed against a live MariaDB instance.

@roger Can you review & merge please?