### PR TITLE
upgrade to jboss-ip-bom 7.0.0.CR2

### DIFF
--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <!-- Keep in sync with parent's <version> in dashbuilder-parent-metadata -->
-    <version.org.jboss.integration-platform>7.0.0.CR1</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>7.0.0.CR2</version.org.jboss.integration-platform>
     <version.org.uberfire>0.9.0-SNAPSHOT</version.org.uberfire>
     <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> in dashbuilder-deps -->
-    <version>7.0.0.CR1</version>
+    <version>7.0.0.CR2</version>
   </parent>
 
   <groupId>org.dashbuilder</groupId>


### PR DESCRIPTION
@romartin when upgrading locally dashbuilder to jboss-ip-bom 7.0.0.CR2 the build fails because of
https://gist.github.com/mbiarnes/82e7c3549f498eba591001640677b542
It appears to be a conflict of elastic search and lucene. This has to be fixed.