### PR TITLE
Revert "upgraded jboss-ip-bom to 6.0.7.Final (#192)"

### DIFF
--- a/dashbuilder-deps/pom.xml
+++ b/dashbuilder-deps/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <!-- Keep in sync with parent's <version> in dashbuilder-parent-metadata -->
-    <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
     <version.org.uberfire>0.8.1-SNAPSHOT</version.org.uberfire>
     <version.org.jboss.errai>3.2.4.Final</version.org.jboss.errai>
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> in dashbuilder-deps -->
-    <version>6.0.7.Final</version>
+    <version>6.0.6.Final</version>
   </parent>
 
   <groupId>org.dashbuilder</groupId>


### PR DESCRIPTION
As ip-bom 6.0.7.Final contains an upgrade to <version.com.thoughtworks.xstream>1.4.9 and this 
contains Java 8 (*non*-backwards compatibile) code, which causes Webpshere to prevent the BPMS
webservice from deploying we have to revert this.