### PR TITLE
added new Zanata 0.6.0 project

### DIFF
--- a/src/main/config/zanata.xml
+++ b/src/main/config/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://translate.jboss.org/</url>
   <project>dashbuilderuf</project>
-  <project-version>0.5.0</project-version>
+  <project-version>0.6.0</project-version>
   <project-type>utf8properties</project-type>
 
   <locales>


### PR DESCRIPTION
Created on Zanata a new project 0.6.0 (copied from the existing Zanata project 0.5.0).
Master branch should point to this new project.
The existing 0.5.0 projects will be removed. A new 0.5.0 Zanata project will be created based on Zanata project 0.4.0.
The new dashbuilder branch 0.5.x (will be branche tomorrow) will point to the new Zanata project 0.5.0.