### PR TITLE
Fix datasource dropdown popover issue

### DIFF
--- a/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/sql/SQLDataSetDefAttributesEditor.java
+++ b/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/sql/SQLDataSetDefAttributesEditor.java
@@ -95,7 +95,7 @@ public class SQLDataSetDefAttributesEditor implements IsWidget, org.dashbuilder.
 
         dataSource.addHelpContent(DataSetEditorConstants.INSTANCE.sql_datasource(),
                 DataSetEditorConstants.INSTANCE.sql_datasource_description(),
-                Placement.BOTTOM);
+                Placement.RIGHT); //bottom placement would interfere with the dropdown
         dbSchema.addHelpContent(DataSetEditorConstants.INSTANCE.sql_schema(),
                 DataSetEditorConstants.INSTANCE.sql_schema_description(),
                 Placement.BOTTOM);


### PR DESCRIPTION
When selecting Datasource, there is a help popover that appears when hovering mouse over the dropdown. However this doesn't work very well with the dropdown - it blocks the dropdown text and appears & disappears erratically when selecting value from the dropdown. This also blocks selenium testing (it doesn't allow clicking elements covered by other elements).

My proposed fix is to change the placement of the dropdown to the right, where it doesn't interfere with the drowdown:

![popoverissue](https://cloud.githubusercontent.com/assets/2716069/20051804/2c595eea-a4d1-11e6-9966-e073f2fce454.png)
