### PR TITLE
maven-compiler-plugin: disable forking + remove duplicated config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,21 +249,6 @@
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <fork>true</fork>
-            <meminitial>128m</meminitial>
-            <maxmem>512m</maxmem>
-            <showDeprecation>true</showDeprecation>
-            <showWarnings>true</showWarnings>
-            <source>${maven.compiler.argument.source}</source>
-            <target>${maven.compiler.argument.target}</target>
-          </configuration>
-        </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
 * jboss-parent already defines source, target, warnings and deprecation
 * fork config removed == forking disabled (default is false)
 * meminitial and memmax are only needed when forking
 * with forking disabled, the performance gain is about 60%
   for the compile-only builds