### PR TITLE
Upgrade IP BOM to 7.0.0.CR5 + related fixes

### DIFF
--- a/dashbuilder-bom/pom.xml
+++ b/dashbuilder-bom/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with the parent version of ../pom.xml (dashbuilder-parent) -->
-    <version>7.0.0.CR4</version>
+    <version>7.0.0.CR5</version>
     <relativePath/>
   </parent>
 

--- a/dashbuilder-distros/pom.xml
+++ b/dashbuilder-distros/pom.xml
@@ -131,7 +131,7 @@
 
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
 
     <dependency>

--- a/dashbuilder-distros/src/main/assembly/assembly-tomcat-7.xml
+++ b/dashbuilder-distros/src/main/assembly/assembly-tomcat-7.xml
@@ -67,6 +67,8 @@
         <include>org.jboss.weld:weld-spi</include>
         <include>org.jboss.weld.environment:weld-environment-common</include>
         <include>org.jboss.classfilewriter:jboss-classfilewriter</include>
+        <include>org.hibernate.javax.persistence:hibernate-jpa-2.1-api:jar</include>
+        <include>org.jboss.logging:jboss-logging:jar</include>
 
         <include>net.jcip:jcip-annotations</include>
         <include>xalan:xalan</include>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-bom</artifactId>
     <!-- Keep in sync with the parent version of dashbuilder-bom/pom.xml -->
-    <version>7.0.0.CR4</version>
+    <version>7.0.0.CR5</version>
   </parent>
 
   <groupId>org.dashbuilder</groupId>


### PR DESCRIPTION
 * CR5 brings JPA 2.1 + Hibernate 5.x
   (upgraded from JPA 2.0 + Hibernate 4.x)

Please don't merge yet. All the IP BOM 7.0.0.CR5 PRs need to be merged together.