### PR TITLE
DASHBUILDE-176: fix ColumnType identification logic

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-csv/src/main/java/org/dashbuilder/dataprovider/csv/CSVParser.java
+++ b/dashbuilder-backend/dashbuilder-dataset-csv/src/main/java/org/dashbuilder/dataprovider/csv/CSVParser.java
@@ -26,6 +26,7 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -141,14 +142,21 @@ public class CSVParser {
             dateFormat.parse(value);
             return ColumnType.DATE;
         } catch (Exception e) {
-            try {
-                DecimalFormat numberFormat = getNumberFormat(columnId);
-                numberFormat.parse(value);
+            DecimalFormat numberParser = getNumberFormat(columnId);
+            if (canBeParsedAsNumber(numberParser, value)) {
                 return ColumnType.NUMBER;
-            } catch (Exception ee) {
+            } else {
                 return ColumnType.LABEL;
             }
         }
+    }
+
+    /* Given value can be parsed as number if the parser successfully consumes the entire input String */
+    protected boolean canBeParsedAsNumber(DecimalFormat parser, String value) {
+        value = value.trim();
+        ParsePosition position = new ParsePosition(0);
+        parser.parse(value, position);
+        return position.getIndex() == value.length();
     }
 
     protected void _processLine(DataSet dataSet, Object[] row, String[] line, List<Integer> columnIdxs) throws Exception {

--- a/dashbuilder-backend/dashbuilder-dataset-csv/src/test/java/org/dashbuilder/dataprovider/csv/CSVParserTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-csv/src/test/java/org/dashbuilder/dataprovider/csv/CSVParserTest.java
@@ -6,7 +6,6 @@ import org.dashbuilder.dataset.DataSet;
 import org.dashbuilder.dataset.def.CSVDataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefFactory;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -23,9 +22,8 @@ public class CSVParserTest {
             .quoteChar('\'')
             .escapeChar('\\')
             .datePattern("YYYY-MM-dd")
-            .numberPattern("###.##")
+            .numberPattern("##.##")
             .buildDef();
-
 
     /* Reproducer of DASHBUILDE-172 */
     @Test
@@ -58,6 +56,20 @@ public class CSVParserTest {
         assertEquals(ColumnType.DATE, dset.getColumnById("Date of birth").getColumnType());
     }
 
+    @Test
+    public void stringFieldStartingWithNumber_shouldBeParsedAsLabel() throws Exception {
+        final String CSV_DATA = "Age,Address\n" +
+                "25,12 Downing street\n" +
+                "75,White House 52";
+
+        CSVFileStorage mockStorage = new MockCSVFileStorage(CSV_DATA);
+        CSVParser testedParser = new CSVParser(csvDataSet, mockStorage);
+        DataSet dset = testedParser.load();
+
+        assertEquals(2, dset.getRowCount());
+        assertEquals(ColumnType.NUMBER, dset.getColumnById("Age").getColumnType());
+        assertEquals(ColumnType.LABEL, dset.getColumnById("Address").getColumnType());
+    }
 
     static class MockCSVFileStorage implements CSVFileStorage {
 


### PR DESCRIPTION
Proposed fix for DASHBUILDE-176. Careful review required - I'm not 100% that this will behave correctly with various DecimalFormats users can specify for a column.