### PR TITLE
SQLDataSetProvider uses 'between' for dynamic date intervals

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/SQLDataSetProvider.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/SQLDataSetProvider.java
@@ -936,7 +936,10 @@ public class SQLDataSetProvider implements DataSetProvider, DataSetDefRegistryLi
                 // Apply the filter
                 ColumnFilter filter;
                 if (min != null && max != null) {
-                    filter = FilterFactory.between(cg.getSourceId(), min, max);
+                    filter = FilterFactory.AND(
+                                 FilterFactory.greaterOrEqualsTo(cg.getSourceId(), min),
+                                 FilterFactory.lowerThan(cg.getSourceId(), max)
+                             );
                 }
                 else if (min != null) {
                     filter = FilterFactory.greaterOrEqualsTo(cg.getSourceId(), min);


### PR DESCRIPTION
Date between includes right endpoint. Because of this there are two days in bar chart when drill-down to DAY
level (as example).