### PR TITLE
DASHBUILDE-217: Make it impossible to to open multiple NavItemEditor …

### DIFF
--- a/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavItemEditor.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavItemEditor.java
@@ -108,6 +108,7 @@ public class NavItemEditor implements IsWidget {
     Command onNewSubgroupCommand;
     Command onNewPerspectiveCommand;
     Command onNewDividerCommand;
+    Command onEditStartedCommand;
     String literalGroup = "Group";
     String literalPerspective = "Perspective";
     String literalDivider = "Divider";
@@ -213,6 +214,10 @@ public class NavItemEditor implements IsWidget {
 
     public void setOnNewDividerCommand(Command onNewDividerCommand) {
         this.onNewDividerCommand = onNewDividerCommand;
+    }
+
+    public void setOnEditStartedCommand(Command onEditStartedCommand) {
+        this.onEditStartedCommand = onEditStartedCommand;
     }
 
     public NavItem getNavItem() {
@@ -359,6 +364,7 @@ public class NavItemEditor implements IsWidget {
     public void onItemClick() {
         if (editEnabled) {
             view.startItemEdition();
+            onEditStarted();
         }
     }
 
@@ -441,5 +447,15 @@ public class NavItemEditor implements IsWidget {
         if (onMoveLastCommand != null) {
             onMoveLastCommand.execute();
         }
+    }
+
+    public void onEditStarted() {
+        if (onEditStartedCommand != null) {
+            onEditStartedCommand.execute();
+        }
+    }
+
+    public void finishEditing() {
+        view.finishItemEdition();
     }
 }

--- a/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavTreeEditor.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavTreeEditor.java
@@ -17,6 +17,7 @@ package org.dashbuilder.client.navigation.widget;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -72,6 +73,7 @@ public class NavTreeEditor implements IsWidget {
     String literalGroup = "Group";
     String literalPerspective = "Perspective";
     String literalDivider = "Divider";
+    Optional<NavItemEditor> currentlyEditedItem = Optional.empty();
 
     @Inject
     public NavTreeEditor(View view, SyncBeanManager beanManager, PerspectiveTreeProvider perspectiveTreeProvider) {
@@ -158,6 +160,7 @@ public class NavTreeEditor implements IsWidget {
         this.navTree = navTree.cloneTree();
         this.navTreeBackup = navTree.cloneTree();
         this.inCreationId = null;
+        this.currentlyEditedItem = Optional.empty();
         _edit(this.navTree);
     }
 
@@ -197,6 +200,7 @@ public class NavTreeEditor implements IsWidget {
         navItemEditor.setOnNewSubgroupCommand(() -> onNewSubGroup((NavGroup) navItem));
         navItemEditor.setOnNewPerspectiveCommand(() -> onNewPerspective((NavGroup) navItem));
         navItemEditor.setOnNewDividerCommand(() -> onNewDivider((NavGroup) navItem));
+        navItemEditor.setOnEditStartedCommand(() -> onEditStarted(navItemEditor));
         navItemEditor.setMoveUpEnabled(!isFirst);
         navItemEditor.setMoveDownEnabled(!isLast);
         navItemEditor.setNewGroupEnabled(newGroupEnabled && subGroupsAllowed);
@@ -265,6 +269,11 @@ public class NavTreeEditor implements IsWidget {
         navTree.setItemDescription(oldItem.getId(), newItem.getDescription());
         navTree.setItemContext(oldItem.getId(), newItem.getContext());
         view.setChangedFlag(true);
+    }
+
+    void onEditStarted(NavItemEditor newEditor) {
+        currentlyEditedItem.ifPresent(oldEditor -> oldEditor.finishEditing());
+        currentlyEditedItem = Optional.of(newEditor);
     }
 
     private void onDeleteItem(NavItem navItem) {

--- a/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/NavItemEditorTest.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/NavItemEditorTest.java
@@ -29,7 +29,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.ext.widgets.common.client.dropdown.PerspectiveDropDown;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/widget/NavTreeEditorTest.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/widget/NavTreeEditorTest.java
@@ -1,0 +1,36 @@
+package org.dashbuilder.client.navigation.widget;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.authz.PerspectiveTreeProvider;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NavTreeEditorTest {
+
+    @Mock
+    private NavTreeEditor.View viewM;
+    @Mock
+    private SyncBeanManager beanManagerM;
+    @Mock
+    private PerspectiveTreeProvider perspectiveTreeProviderM;
+
+    @Test
+    public void itShouldBeImpossibleToOpenMultipleNavItemEditorInputs() { // DASHBUILDE-217
+        NavTreeEditor treeEditor = new NavTreeEditor(viewM,
+                                                     beanManagerM,
+                                                     perspectiveTreeProviderM);
+
+        NavItemEditor first = mock(NavItemEditor.class);
+        NavItemEditor second = mock(NavItemEditor.class);
+
+        treeEditor.onEditStarted(first);
+        treeEditor.onEditStarted(second);
+
+        verify(first).finishEditing();
+    }
+}


### PR DESCRIPTION
…inputs

The proposed solution is to add handler for `BlurEvent`, which is fired when the input field loses focus (when user clicks away or starts editing another item in the nav tree).