### PR TITLE
DASHBUILDE-224: fix tooltip not disappearing

### DIFF
--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/ToggleSwitchEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/ToggleSwitchEditorView.java
@@ -1,5 +1,7 @@
 package org.dashbuilder.common.client.editor;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -13,8 +15,6 @@ import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.ToggleSwitch;
-
-import javax.enterprise.context.Dependent;
 
 /**
  * <p>The ValueBoxEditor view.</p>
@@ -79,7 +79,6 @@ public class ToggleSwitchEditorView extends Composite implements ToggleSwitchEdi
     public ToggleSwitchEditor.View showError(final SafeHtml message) {
         contents.addStyleName(STYLE_ERROR);
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         return this;
     }
 
@@ -87,7 +86,6 @@ public class ToggleSwitchEditorView extends Composite implements ToggleSwitchEdi
     public ToggleSwitchEditor.View clearError() {
         contents.removeStyleName(STYLE_ERROR);
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         return this;
     }
 

--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/ValueBoxEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/ValueBoxEditorView.java
@@ -1,5 +1,7 @@
 package org.dashbuilder.common.client.editor;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -12,11 +14,8 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.ValueBoxBase;
 import com.google.gwt.user.client.ui.Widget;
-import org.gwtbootstrap3.client.ui.Popover;
 import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.Placement;
-
-import javax.enterprise.context.Dependent;
 
 /**
  * <p>The ValueBoxEditor view.</p>
@@ -74,7 +73,6 @@ public class ValueBoxEditorView<T> extends Composite implements ValueBoxEditor.V
     public ValueBoxEditor.View<T> showError(SafeHtml message) {
         contents.addStyleName(STYLE_ERROR);
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         return this;
     }
 
@@ -82,7 +80,6 @@ public class ValueBoxEditorView<T> extends Composite implements ValueBoxEditor.V
     public ValueBoxEditor.View<T> clearError() {
         contents.removeStyleName(STYLE_ERROR);
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         return this;
     }
 

--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/file/FileUploadEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/file/FileUploadEditorView.java
@@ -1,5 +1,7 @@
 package org.dashbuilder.common.client.editor.file;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -10,13 +12,10 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.FormPanel;
 import com.google.gwt.user.client.ui.Widget;
-import org.gwtbootstrap3.client.ui.Popover;
 import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.Placement;
 import org.uberfire.ext.widgets.common.client.common.FileUpload;
 import org.uberfire.mvp.Command;
-
-import javax.enterprise.context.Dependent;
 
 /**
  * <p>The FileUploadEditor view.</p>
@@ -162,7 +161,6 @@ public class FileUploadEditorView extends Composite implements FileUploadEditor.
     public FileUploadEditor.View showError(final SafeHtml message) {
         mainPanel.addStyleName(STYLE_ERROR);
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         return this;
     }
 
@@ -170,9 +168,6 @@ public class FileUploadEditorView extends Composite implements FileUploadEditor.
     public FileUploadEditor.View clearError() {
         mainPanel.removeStyleName(STYLE_ERROR);
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         return this;
     }
-    
-
 }

--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/DropDownEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/DropDownEditorView.java
@@ -19,25 +19,15 @@ import javax.enterprise.context.Dependent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTMLPanel;
-import com.google.gwt.user.client.ui.InlineLabel;
-import com.google.gwt.user.client.ui.SimplePanel;
-import com.google.gwt.user.client.ui.ValueBoxBase;
 import com.google.gwt.user.client.ui.Widget;
-import org.dashbuilder.common.client.editor.ValueBoxEditor;
-import org.gwtbootstrap3.client.ui.DropDown;
-import org.gwtbootstrap3.client.ui.DropDownMenu;
-import org.gwtbootstrap3.client.ui.Popover;
 import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.Placement;
 import org.uberfire.ext.widgets.common.client.dropdown.LiveSearchDropDown;
@@ -103,7 +93,6 @@ public class DropDownEditorView extends Composite implements DropDownEditor.View
     @Override
     public DropDownEditorView showError(SafeHtml message) {
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanel());
         errorPanel.addStyleName(style.errorPanelWithError());
         return this;
@@ -112,7 +101,6 @@ public class DropDownEditorView extends Composite implements DropDownEditor.View
     @Override
     public DropDownEditorView clearError() {
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanelWithError());
         errorPanel.addStyleName(style.errorPanel());
         return this;

--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/DropDownImageListEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/DropDownImageListEditorView.java
@@ -1,23 +1,27 @@
 package org.dashbuilder.common.client.editor.list;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeUri;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.*;
-import org.gwtbootstrap3.client.ui.*;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.InlineLabel;
+import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Anchor;
+import org.gwtbootstrap3.client.ui.DropDown;
+import org.gwtbootstrap3.client.ui.DropDownMenu;
 import org.gwtbootstrap3.client.ui.Image;
+import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.Placement;
 import org.uberfire.mvp.Command;
-
-import javax.enterprise.context.Dependent;
 
 /**
  * <p>The ImageListEditor view that uses a drop down as selector.</p>
@@ -141,7 +145,6 @@ public class DropDownImageListEditorView<T> extends Composite implements DropDow
     @Override
     public ImageListEditorView<T> showError(SafeHtml message) {
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanel());
         errorPanel.addStyleName(style.errorPanelWithError());
         return this;
@@ -150,7 +153,6 @@ public class DropDownImageListEditorView<T> extends Composite implements DropDow
     @Override
     public ImageListEditorView<T> clearError() {
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanelWithError());
         errorPanel.addStyleName(style.errorPanel());
         return this;

--- a/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/HorizImageListEditorView.java
+++ b/dashbuilder-client/dashbuilder-common-client/src/main/java/org/dashbuilder/common/client/editor/list/HorizImageListEditorView.java
@@ -1,22 +1,27 @@
 package org.dashbuilder.common.client.editor.list;
 
+import javax.enterprise.context.Dependent;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.editor.client.Editor;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeUri;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.*;
-import org.gwtbootstrap3.client.ui.*;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.HasAlignment;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Image;
+import org.gwtbootstrap3.client.ui.Tooltip;
 import org.gwtbootstrap3.client.ui.constants.Placement;
 import org.uberfire.mvp.Command;
-
-import javax.enterprise.context.Dependent;
 
 /**
  * <p>The ImageListEditor default view. It places images in an horizontal way.</p>
@@ -88,7 +93,8 @@ public class HorizImageListEditorView<T> extends Composite implements ImageListE
         tooltip.setWidget(image);
         tooltip.setContainer("body");
         tooltip.setPlacement(Placement.BOTTOM);
-        tooltip.setShowDelayMs(1);
+        tooltip.setIsAnimated(false);
+        tooltip.setShowDelayMs(100);
 
         final HTML label = new HTML(heading.asString());
         final HorizontalPanel labelPanel = new HorizontalPanel();
@@ -101,8 +107,9 @@ public class HorizImageListEditorView<T> extends Composite implements ImageListE
         mainPanel.add(panel);
 
         image.addClickHandler(e -> {
-            clickCommand.execute();
             tooltip.hide();
+            tooltip.destroy();
+            clickCommand.execute();
         });
 
         return this;
@@ -122,7 +129,6 @@ public class HorizImageListEditorView<T> extends Composite implements ImageListE
     @Override
     public ImageListEditorView<T> showError(SafeHtml message) {
         errorTooltip.setTitle(message.asString());
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanel());
         errorPanel.addStyleName(style.errorPanelWithError());
         return null;
@@ -131,7 +137,6 @@ public class HorizImageListEditorView<T> extends Composite implements ImageListE
     @Override
     public ImageListEditorView<T> clearError() {
         errorTooltip.setTitle("");
-        errorTooltip.reconfigure();
         errorPanel.removeStyleName(style.errorPanelWithError());
         errorPanel.addStyleName(style.errorPanel());
         return this;


### PR DESCRIPTION
Proposed fix to [DASHBUILDE-224](https://issues.jboss.org/browse/DASHBUILDE-224).

I tried several things, but the `hide()` in the image click handler doesn't work properly - in combination with too small showDelayMs it caused that the tooltip immediately re-appeared and then never disappeared.

Solved this by increasing showDelayMs slightly and disabling animation for this tooltip, which seems to be causing the issue in firefox.

Also I removed all usages of deprecated `tooltip.reconfigure()`, which is currently implemented like this in gwt bootstrap:
```
    /**
     * Reconfigures the tooltip.
     * @deprecated will be removed after the next release.
     */
    public void reconfigure() {
        // Do nothing. No longer necessary.
    }
```
