### PR TITLE
Upgrade to Errai 4.0.1-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <version.com.ahome-it.lienzo-charts>1.0.241-RC1</version.com.ahome-it.lienzo-charts>
     <version.com.ahome-it.lienzo-core>2.0.241-RC1</version.com.ahome-it.lienzo-core>
     <version.org.uberfire>1.1.0-SNAPSHOT</version.org.uberfire>
-    <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jboss.errai>4.0.1-SNAPSHOT</version.org.jboss.errai>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
     <!-- Version 4.3.2.Final which is coming from ip-bom is not compatible with with GWT 2.8.0 -->


### PR DESCRIPTION
Hey @dgutierr ,

Was trying to run the dashbuilder showcase webapp but the GWT compilation complains, so actually the webapp module does not builds. 

I't s due to the use of latest Uberfire `1.1.0-SNAPSHOT,` which depends on Errai `4.0.1-SNAPSHOT`; but Dashbuilder is still using an old version `4.0.0-SNAPSHOT`.

Thanks!