### PR TITLE
Add Uberfire Preferences dependencies.

### DIFF
--- a/dashbuilder-webapp/pom.xml
+++ b/dashbuilder-webapp/pom.xml
@@ -328,6 +328,25 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- UberFire Preferences. -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-ui-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- UberFire Security (Extension) -->
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -664,6 +683,9 @@
             <compileSourcesArtifact>org.uberfire:uberfire-widgets-properties-editor-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-widgets-properties-editor-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-simple-docks-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.uberfire:uberfire-preferences-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.uberfire:uberfire-preferences-client</compileSourcesArtifact>
+            <compileSourcesArtifact>org.uberfire:uberfire-preferences-ui-client</compileSourcesArtifact>
 
             <!-- UberFire -->
             <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>

--- a/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
+++ b/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
@@ -7,6 +7,7 @@
 
   <inherits name="org.uberfire.ext.plugin.RuntimePluginClient"/>
   <inherits name="org.uberfire.ext.security.management.UberfireSecurityManagementWorkbench"/>
+  <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
 
   <inherits name="org.dashbuilder.DashbuilderClientAll"/>
   <inherits name="org.dashbuilder.DisplayerEditor"/>


### PR DESCRIPTION
Hey @dgutierr @psiroky 
As from this PR, now uberfire-commons-edtior modules depend on the Preferences API:
https://github.com/AppFormer/uberfire/pull/744
Thanks!