### PR TITLE
AF-546: Reduce startup time of AppFormer apps and workbenches

### DIFF
--- a/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/explorer/ContentExplorerScreen.java
+++ b/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/explorer/ContentExplorerScreen.java
@@ -15,16 +15,15 @@
  */
 package org.dashbuilder.client.cms.screen.explorer;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.dashbuilder.client.cms.resources.i18n.ContentManagerI18n;
 import org.dashbuilder.client.cms.widget.PerspectivesExplorer;
 import org.dashbuilder.client.navigation.NavigationManager;
 import org.dashbuilder.client.navigation.widget.NavTreeEditor;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
@@ -34,6 +33,8 @@ import org.uberfire.ext.plugin.client.widget.popup.NewPluginPopUp;
 import org.uberfire.ext.plugin.model.PluginType;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
+
+import com.google.gwt.user.client.ui.IsWidget;
 
 @ApplicationScoped
 @WorkbenchScreen(identifier = ContentExplorerScreen.SCREEN_ID)
@@ -90,7 +91,7 @@ public class ContentExplorerScreen {
         this.view.init(this);
     }
 
-    @AfterInitialization
+    @PostConstruct
     private void init() {
         navTreeEditor.setLiteralPerspective(i18n.capitalizeFirst(i18n.getPerspectiveResourceName()));
         navTreeEditor.setNewGroupEnabled(true);

--- a/dashbuilder-client/dashbuilder-displayer-editor/src/main/java/org/dashbuilder/client/editor/DisplayerEditorEntryPoint.java
+++ b/dashbuilder-client/dashbuilder-displayer-editor/src/main/java/org/dashbuilder/client/editor/DisplayerEditorEntryPoint.java
@@ -15,14 +15,13 @@
  */
 package org.dashbuilder.client.editor;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.annotation.PostConstruct;
 
 import org.dashbuilder.displayer.DisplayerAttributeDef;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 
 @EntryPoint
-@ApplicationScoped
 public class DisplayerEditorEntryPoint {
 
     /**
@@ -30,7 +29,7 @@ public class DisplayerEditorEntryPoint {
      * does not show all the attributes in the "Display" tab The fix is to force the DisplayerAttributeDef static
      * fields to initialize on startup.
      */
-    @AfterInitialization
+    @PostConstruct
     public void init() {
         DisplayerAttributeDef def = DisplayerAttributeDef.TITLE;
     }

--- a/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/plugin/PerspectivePluginManager.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/plugin/PerspectivePluginManager.java
@@ -15,17 +15,17 @@
  */
 package org.dashbuilder.client.navigation.plugin;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.dashbuilder.client.navigation.NavigationManager;
 import org.dashbuilder.client.navigation.event.PerspectivePluginsChangedEvent;
 import org.dashbuilder.navigation.NavItem;
@@ -34,7 +34,6 @@ import org.dashbuilder.navigation.service.LayoutTemplateInfo;
 import org.dashbuilder.navigation.service.PerspectivePluginServices;
 import org.dashbuilder.navigation.workbench.NavWorkbenchCtx;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.type.ClientTypeRegistry;
@@ -48,6 +47,8 @@ import org.uberfire.ext.plugin.model.Plugin;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.workbench.model.ActivityResourceType;
+
+import com.google.gwt.user.client.ui.IsWidget;
 
 @EntryPoint
 @ApplicationScoped
@@ -74,7 +75,7 @@ public class PerspectivePluginManager {
         this.perspectivesChangedEvent = perspectivesChangedEvent;
     }
 
-    @AfterInitialization
+    @PostConstruct
     private void init() {
         loadPlugins(plugins -> {});
     }

--- a/dashbuilder-webapp/src/main/java/org/dashbuilder/client/ShowcaseEntryPoint.java
+++ b/dashbuilder-webapp/src/main/java/org/dashbuilder/client/ShowcaseEntryPoint.java
@@ -15,11 +15,13 @@
  */
 package org.dashbuilder.client;
 
-import com.google.gwt.animation.client.Animation;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.ui.RootPanel;
+import static org.uberfire.workbench.events.NotificationEvent.NotificationType.INFO;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
 import org.dashbuilder.client.cms.resources.i18n.ContentManagerI18n;
 import org.dashbuilder.client.dashboard.DashboardManager;
 import org.dashbuilder.client.dashboard.DashboardPerspectiveActivity;
@@ -28,13 +30,11 @@ import org.dashbuilder.client.navigation.NavTreeDefinitions;
 import org.dashbuilder.client.navigation.NavigationManager;
 import org.dashbuilder.client.resources.i18n.AppConstants;
 import org.dashbuilder.client.security.PermissionTreeSetup;
-import org.dashbuilder.displayer.DisplayerAttributeDef;
 import org.dashbuilder.navigation.NavItem;
 import org.dashbuilder.navigation.NavTree;
 import org.dashbuilder.navigation.workbench.NavWorkbenchCtx;
 import org.dashbuilder.shared.dashboard.events.DashboardDeletedEvent;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.uberfire.client.mvp.PlaceManager;
@@ -42,11 +42,11 @@ import org.uberfire.ext.security.management.client.ClientUserSystemManager;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
 
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
-import static org.uberfire.workbench.events.NotificationEvent.NotificationType.INFO;
+import com.google.gwt.animation.client.Animation;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.RootPanel;
 
 /**
  * Entry-point for the Dashbuilder showcase
@@ -83,7 +83,7 @@ public class ShowcaseEntryPoint {
     @Inject
     private ContentManagerI18n contentManagerI18n;
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         // OPTIONAL: Rename perspectives to dashboards in CMS
         //customizeCMSTexts();


### PR DESCRIPTION
Replace @AfterInitializations with @PostConstructs.
(Allows RPC calls to be combined into a single playload.)