### PR TITLE
Upgrade to GWT 2.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <version.javax.xml.stream>1.0-2</version.javax.xml.stream>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
-    <version.com.google.gwt>2.8.0</version.com.google.gwt>
+    <version.com.google.gwt>2.8.1</version.com.google.gwt>
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
     <version.com.googlecode.jtype>0.1.1</version.com.googlecode.jtype>
     <version.org.elasticsearch>2.1.2</version.org.elasticsearch>


### PR DESCRIPTION
Upgrading because Elemental2 requires GWT 2.8.1. @porcelli could you please take a look?