### PR TITLE
DASHBUILDE-247: Disable perspective items creation in navigation group editor

### DIFF
--- a/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavTreeEditor.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavTreeEditor.java
@@ -77,6 +77,7 @@ public class NavTreeEditor implements IsWidget {
     String literalDivider = "Divider";
     Optional<NavItemEditor> currentlyEditedItem = Optional.empty();
     Map<String, Integer> navItemMaxLevelsMap = new HashMap<>();
+    Map<String, Boolean> navItemNewPerspectiveFlagMap = new HashMap<>();
 
     @Inject
     public NavTreeEditor(View view, SyncBeanManager beanManager, PerspectiveTreeProvider perspectiveTreeProvider) {
@@ -125,6 +126,18 @@ public class NavTreeEditor implements IsWidget {
 
     public boolean isNewPerspectiveEnabled() {
         return newPerspectiveEnabled;
+    }
+
+    public boolean isNewPerspectiveEnabled(String navItemId) {
+        if (navItemNewPerspectiveFlagMap.containsKey(navItemId)) {
+            return navItemNewPerspectiveFlagMap.get(navItemId);
+        } else {
+            return newPerspectiveEnabled;
+        }
+    }
+
+    public void setNewPerspectiveEnabled(String navItemId, boolean newPerspectiveEnabled) {
+        navItemNewPerspectiveFlagMap.put(navItemId, newPerspectiveEnabled);
     }
 
     public void setNewPerspectiveEnabled(boolean newPerspectiveEnabled) {
@@ -224,7 +237,7 @@ public class NavTreeEditor implements IsWidget {
         navItemEditor.setMoveDownEnabled(!isLast);
         navItemEditor.setNewGroupEnabled(newGroupEnabled && subGroupsAllowed);
         navItemEditor.setNewDividerEnabled(newDividerEnabled && childrenAllowed);
-        navItemEditor.setNewPerspectiveEnabled(newPerspectiveEnabled && childrenAllowed);
+        navItemEditor.setNewPerspectiveEnabled(isNewPerspectiveEnabled(navItem.getId()) && childrenAllowed);
         navItemEditor.setGotoPerspectiveEnabled(gotoPerspectiveEnabled);
         navItemEditor.setVisiblePerspectiveIds(getPerspectiveIds(true));
         navItemEditor.setHiddenPerspectiveIds(getPerspectiveIds(false));

--- a/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/widget/NavTreeEditorTest.java
+++ b/dashbuilder-client/dashbuilder-navigation-client/src/test/java/org/dashbuilder/client/navigation/widget/NavTreeEditorTest.java
@@ -118,6 +118,16 @@ public class NavTreeEditorTest {
     }
 
     @Test
+    public void testNewPerspectiveDisabled() {
+        NavTreeEditor treeEditor = new NavTreeEditor(viewM, beanManagerM, perspectiveTreeProviderM);
+        treeEditor.setNewPerspectiveEnabled("level1a", false);
+        treeEditor.edit(NAV_TREE);
+
+        verify(navItemEditor, times(4)).setNewPerspectiveEnabled(true);
+        verify(navItemEditor, times(1)).setNewPerspectiveEnabled(false);
+    }
+
+    @Test
     public void testFinishEdition() {
         NavTreeEditor treeEditor = spy(new NavTreeEditor(viewM, beanManagerM, perspectiveTreeProviderM));
         treeEditor.edit(NAV_TREE);


### PR DESCRIPTION
Fix + test.

Perspective creation can be disabled for a concrete nav tree node by calling the following method.

navTreeEditor.setNewPerspectiveEnabled("navGroupId", false);

The following is a a similar example of changing the navTreeEditor setting during app initialization:  

https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-wb-parent/kie-wb-webapp/src/main/java/org/kie/workbench/client/KieWorkbenchEntryPoint.java#L98

@paulovmr Can you review please?


