### PR TITLE
Skip WildFly dist unpacking when skipping GWT compilation

### DIFF
--- a/dashbuilder-webapp/pom.xml
+++ b/dashbuilder-webapp/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
     <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly.gwt.sdm}</errai.jboss.home>
+    <gwt.compiler.skip>false</gwt.compiler.skip>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
   </properties>
 
@@ -787,6 +788,7 @@
                   <outputDirectory>${project.build.directory}</outputDirectory>
                 </artifactItem>
               </artifactItems>
+              <skip>${gwt.compiler.skip}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
No need to unpack the WildFly distribution when the GWT compilation is
skipped. It is not being used and only slows down the build (and takes
additional disk space)

@dgutierr could you please review?