### PR TITLE
Remove duplicate errai-common dependency from dashbuilder-common-client.

### DIFF
--- a/dashbuilder-client/dashbuilder-common-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-common-client/pom.xml
@@ -55,11 +55,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
     </dependency>
 


### PR DESCRIPTION
(cherry picked from commit d02513275db8cc9b326b8994499d3448f835b9ef)