### PR TITLE
bumped up master version

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-cdi</artifactId>

--- a/dashbuilder-backend/dashbuilder-dataset-core/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-core</artifactId>

--- a/dashbuilder-backend/dashbuilder-dataset-csv/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-csv/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-csv</artifactId>

--- a/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-backend</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-sql-tests</artifactId>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-sql</artifactId>

--- a/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
+++ b/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-backend</artifactId>

--- a/dashbuilder-backend/dashbuilder-services/pom.xml
+++ b/dashbuilder-backend/dashbuilder-services/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-services</artifactId>

--- a/dashbuilder-backend/pom.xml
+++ b/dashbuilder-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder-bom/pom.xml
+++ b/dashbuilder-bom/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.dashbuilder</groupId>
   <artifactId>dashbuilder-bom</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dashbuilder BOM (Bill Of Materials)</name>

--- a/dashbuilder-client/dashbuilder-cms-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-cms-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-cms-client</artifactId>

--- a/dashbuilder-client/dashbuilder-common-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-common-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-common-client</artifactId>

--- a/dashbuilder-client/dashbuilder-dataset-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-dataset-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-client</artifactId>

--- a/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
+++ b/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-editor</artifactId>

--- a/dashbuilder-client/dashbuilder-displayer-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-client</artifactId>

--- a/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-editor</artifactId>

--- a/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
+++ b/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-screen</artifactId>

--- a/dashbuilder-client/dashbuilder-navigation-client/pom.xml
+++ b/dashbuilder-client/dashbuilder-navigation-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-client</artifactId>

--- a/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-chartjs/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-chartjs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-renderers</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-renderers</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderer-default</artifactId>

--- a/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-google/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-google/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-renderers</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderer-google</artifactId>

--- a/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-lienzo/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-lienzo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-renderers</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder-client/dashbuilder-renderers/pom.xml
+++ b/dashbuilder-client/dashbuilder-renderers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderers</artifactId>

--- a/dashbuilder-client/dashbuilder-widgets/pom.xml
+++ b/dashbuilder-client/dashbuilder-widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-client</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder-client/pom.xml
+++ b/dashbuilder-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder-distros/pom.xml
+++ b/dashbuilder-distros/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder-packaging/dashbuilder-all/pom.xml
+++ b/dashbuilder-packaging/dashbuilder-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-all</artifactId>

--- a/dashbuilder-packaging/dashbuilder-client-all/pom.xml
+++ b/dashbuilder-packaging/dashbuilder-client-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-client-all</artifactId>

--- a/dashbuilder-packaging/dashbuilder-server-all/pom.xml
+++ b/dashbuilder-packaging/dashbuilder-server-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-server-all</artifactId>

--- a/dashbuilder-packaging/pom.xml
+++ b/dashbuilder-packaging/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder-shared/dashbuilder-dataset-api/pom.xml
+++ b/dashbuilder-shared/dashbuilder-dataset-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-api</artifactId>

--- a/dashbuilder-shared/dashbuilder-dataset-shared/pom.xml
+++ b/dashbuilder-shared/dashbuilder-dataset-shared/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-shared</artifactId>

--- a/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
+++ b/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-api</artifactId>

--- a/dashbuilder-shared/dashbuilder-json/pom.xml
+++ b/dashbuilder-shared/dashbuilder-json/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-json</artifactId>

--- a/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
+++ b/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-api</artifactId>

--- a/dashbuilder-shared/dashbuilder-services-api/pom.xml
+++ b/dashbuilder-shared/dashbuilder-services-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-services-api</artifactId>

--- a/dashbuilder-shared/dashbuilder-validations/pom.xml
+++ b/dashbuilder-shared/dashbuilder-validations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-shared</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder-shared/pom.xml
+++ b/dashbuilder-shared/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder-webapp/pom.xml
+++ b/dashbuilder-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.dashbuilder</groupId>
   <artifactId>dashbuilder-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dashbuilder Project</name>


### PR DESCRIPTION
since for the kie 7.4.0. release a new branch will be created, so for dahsbuilder too.
the version on the new branch 1.0.x will get 1.0.0-SNAPSHOT - so to prevent clashing SNAPSHOTs with the same version on different branches master had to be upgraded to 1.1.0-SNAPSHOT