### PR TITLE
Add org.w3c.dom.UserDataHandler into ban-duplicate ignore list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,10 @@
                       <!-- Duplicated by XStream's transitive deps, with very little chance to get properly fixed -->
                       <ignoreClass>org.xmlpull.v1.XmlPullParserException</ignoreClass>
                       <ignoreClass>org.xmlpull.v1.XmlPullParser</ignoreClass>
-                      <!-- Duplicated in xml-apis:xml-apis:jar:1.4.01 and xerces:xercesImpl:jar:2.11.0.SP4. The class is identical
+                      <!-- Duplicated in xml-apis:xml-apis:jar:1.4.01 and xerces:xercesImpl:jar:2.11.0.SP4 and jaxen-1.1.6. There are class identical
                            and there is very little chance this will get ever fixed. -->
                       <ignoreClass>org.w3c.dom.ElementTraversal</ignoreClass>
+                      <ignoreClass>org.w3c.dom.UserDataHandler</ignoreClass>
                     </ignoreClasses>
                     <dependencies>
                       <!-- gwt-dev bundles dozens of different 3rd party dependencies, but can not be usually excluded


### PR DESCRIPTION
I spot a error building in master branch:
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BanDuplicateClasses failed with message:
Duplicate classes found:

  Found in:
    xml-apis:xml-apis:jar:1.4.01:test
    jaxen:jaxen:jar:1.1.6.redhat-1:compile
  Duplicate classes:
    org/w3c/dom/UserDataHandler.class

This PR is to fix this.