### PR TITLE
[AF-549-elastic]: removed old dependencies that generated conflict with new ES version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <version.com.google.gwt>2.8.1</version.com.google.gwt>
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
     <version.com.googlecode.jtype>0.1.1</version.com.googlecode.jtype>
-    <version.org.elasticsearch>2.1.2</version.org.elasticsearch>
 
     <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
@@ -62,6 +61,7 @@
 
     <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
           two versions are being updated on the IP BOM.-->
+    <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
     <version.com.fasterxml.jackson>2.6.2</version.com.fasterxml.jackson>
     <version.commons-cli>1.3.1</version.commons-cli>
 
@@ -644,11 +644,6 @@
       </dependency>
 
       <!-- Elastic search and transitive dependencies for it. -->
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${version.org.elasticsearch}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.apache.lucene</groupId>
@@ -660,30 +655,6 @@
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-queryparser</artifactId>
         <version>${version.org.apache.lucene}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-smile</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-cbor</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
       </dependency>
 
       <!-- Required to run the ElasticSearch server when performing the unit test executions.


### PR DESCRIPTION
When migrated datasets to kie-soup some dependencies were not deleted generating some conflicts. ES dependencies removed from here.

Related to: https://github.com/AppFormer/uberfire/pull/882

@dgutierr @romartin please review