### PR TITLE
AF-1149: Dashbuilder not closing ResultSets and Statements

### DIFF
--- a/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/pom.xml
@@ -89,6 +89,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/ResultSetConsumer.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/ResultSetConsumer.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.sql;
+
+import java.sql.ResultSet;
+
+@FunctionalInterface
+public interface ResultSetConsumer<R> {
+
+    /**
+     * Consumes the given data set and produces a result
+     *
+     * @param resultSet The {@link ResultSet} to consume
+     * @return R The resulting object
+     */
+    R consume(ResultSet resultSet);
+
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/ResultSetHandler.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/ResultSetHandler.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.sql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class ResultSetHandler {
+
+    private ResultSet resultSet;
+    private Statement statement;
+
+    public ResultSetHandler(ResultSet resultSet, Statement statement) {
+        this.resultSet = resultSet;
+        this.statement = statement;
+    }
+
+    public ResultSet getResultSet() {
+        return resultSet;
+    }
+
+    public Statement getStatement() {
+        return statement;
+    }
+
+    public void close() throws SQLException {
+        resultSet.close();
+        statement.close();
+    }
+}

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/SQLDataSetProvider.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/SQLDataSetProvider.java
@@ -17,7 +17,6 @@ package org.dashbuilder.dataprovider.sql;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -407,16 +406,15 @@ public class SQLDataSetProvider implements DataSetProvider, DataSetDefRegistryLi
         return result.metadata;
     }
 
-    protected List<Column> _getColumns(SQLDataSetDef def, Connection conn) throws Exception {
-        Dialect dialect = JDBCUtils.dialect(conn);
-        if (!StringUtils.isBlank(def.getDbSQL())) {
-            Select query = SQLFactory.select(conn).from(def.getDbSQL()).limit(1);
-            return JDBCUtils.getColumns(logSQL(query).fetch(), dialect.getExcludedColumns());
-        }
-        else {
-            Select query = SQLFactory.select(conn).from(_createTable(def)).limit(1);
-            return JDBCUtils.getColumns(logSQL(query).fetch(), dialect.getExcludedColumns());
-        }
+    protected List<Column> _getColumns(SQLDataSetDef def, Connection conn) {
+        final Dialect dialect = JDBCUtils.dialect(conn);
+        Select q = SQLFactory.select(conn);
+        q = (!StringUtils.isBlank(def.getDbSQL()) ? q.from(def.getDbSQL()) : q.from(_createTable(def))).limit(1);
+        return logSQL(q).fetch(new ResultSetConsumer<List<Column>>() {
+            public List<Column> consume(ResultSet _rs) {
+                return JDBCUtils.getColumns(_rs, dialect.getExcludedColumns());
+            }
+        });
     }
 
     protected int _getRowCount(DataSetMetadata metadata, SQLDataSetDef def, Connection conn) throws Exception {
@@ -670,13 +668,8 @@ public class SQLDataSetProvider implements DataSetProvider, DataSetDefRegistryLi
                     }
 
                     // Fetch the results and build the data set
-                    ResultSet _results = logSQL(_query).fetch();
                     List<DataColumn> columns = calculateColumns(null);
-                    DataSet dataSet = _buildDataSet(columns, _results);
-                    if (trim && postProcessingOps.isEmpty()) {
-                        dataSet.setRowCountNonTrimmed(totalRows);
-                    }
-                    return dataSet;
+                    return buildDataSet(columns, trim, totalRows);
                 }
                 // ... or a list of operations.
                 else {
@@ -737,17 +730,28 @@ public class SQLDataSetProvider implements DataSetProvider, DataSetDefRegistryLi
                     }
 
                     // Fetch the results and build the data set
-                    ResultSet _results = logSQL(_query).fetch();
                     List<DataColumn> columns = calculateColumns(groupOp);
-                    DataSet dataSet = _buildDataSet(columns, _results);
-                    if (trim && postProcessingOps.isEmpty()) {
-                        dataSet.setRowCountNonTrimmed(totalRows);
-                    }
-                    return dataSet;
+                    return buildDataSet(columns, trim, totalRows);
                 }
             } finally {
                 conn.close();
             }
+        }
+
+        protected DataSet buildDataSet(final List<DataColumn> columns, boolean trim, int totalRows) throws Exception {
+            DataSet dataSet = logSQL(_query).fetch(new ResultSetConsumer<DataSet>() {
+                public DataSet consume(ResultSet _rs) {
+                    try {
+                        return _buildDataSet(columns, _rs);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+            if (trim && postProcessingOps.isEmpty()) {
+                dataSet.setRowCountNonTrimmed(totalRows);
+            }
+            return dataSet;
         }
 
         protected DateIntervalType calculateDateInterval(ColumnGroup cg) {
@@ -793,22 +797,20 @@ public class SQLDataSetProvider implements DataSetProvider, DataSetDefRegistryLi
                 _appendIntervalSelection(intervalSelect, _limitsQuery);
             }
 
-            try {
-                // Fetch the date
-                ResultSet rs = logSQL(_limitsQuery
-                        .where(_dateColumn.notNull())
-                        .orderBy(min ? _dateColumn.asc() : _dateColumn.desc())
-                        .limit(1)).fetch();
+            _limitsQuery = _limitsQuery.where(_dateColumn.notNull())
+                    .orderBy(min ? _dateColumn.asc() : _dateColumn.desc())
+                    .limit(1);
 
-                if (!rs.next()) {
-                    return null;
-                } else {
-                    return rs.getDate(1);
+            return logSQL(_limitsQuery).fetch(new ResultSetConsumer<Date>() {
+                public Date consume(ResultSet rs) {
+                    try {
+                        return rs.next() ? rs.getDate(1) : null;
+                    } catch (Exception e) {
+                        log.error("Error reading date limit from query results", e);
+                        return null;
+                    }
                 }
-            } catch (SQLException e) {
-                log.error("Error reading date limit from query results", e);
-                return null;
-            }
+            });
         }
 
         protected List<DataColumn> calculateColumns(DataSetGroup gOp) {

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/dialect/SQLServerDialect.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/main/java/org/dashbuilder/dataprovider/sql/dialect/SQLServerDialect.java
@@ -15,7 +15,7 @@
  */
 package org.dashbuilder.dataprovider.sql.dialect;
 
-import java.sql.SQLException;
+import java.sql.ResultSet;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.ArrayList;
 
 import org.dashbuilder.dataprovider.sql.JDBCUtils;
+import org.dashbuilder.dataprovider.sql.ResultSetConsumer;
 import org.dashbuilder.dataprovider.sql.model.Column;
 import org.dashbuilder.dataprovider.sql.model.Select;
 import org.dashbuilder.dataprovider.sql.model.SortColumn;
@@ -122,10 +123,15 @@ public class SQLServerDialect extends DefaultDialect {
         try {
             // Disable limits & fetch results
             select.limit(0).offset(0);
-            return JDBCUtils.getColumns(select.fetch(), null);
-        }
-        catch (SQLException e) {
-            return Collections.emptyList();
+            return select.fetch(new ResultSetConsumer<List<Column>>() {
+                public List<Column> consume(ResultSet rs) {
+                    try {
+                        return JDBCUtils.getColumns(rs, null);
+                    } catch (Exception e) {
+                        return Collections.emptyList();
+                    }
+                }
+            });
         }
         finally {
             // Restore original limits

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/JDBCUtilsTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/JDBCUtilsTest.java
@@ -15,9 +15,7 @@
  */
 package org.dashbuilder.dataprovider.sql;
 
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.Types;
+import java.sql.*;
 import java.util.List;
 
 import org.dashbuilder.dataprovider.sql.JDBCUtils;
@@ -36,14 +34,28 @@ import static org.mockito.Mockito.*;
 public class JDBCUtilsTest {
 
     @Mock
-    ResultSet resultSet;
+    Connection connection;
     
+    @Mock
+    Statement statement;
+
+    @Mock
+    ResultSet resultSet;
+
     @Mock
     ResultSetMetaData metaData;
     
     @Before
     public void setUp() throws Exception {
+        when(connection.createStatement()).thenReturn(statement);
         when(resultSet.getMetaData()).thenReturn(metaData);
+    }
+
+    @Test
+    public void testStatementClose() throws Exception {
+        JDBCUtils.execute(connection, "sql");
+        verify(statement).execute("sql");
+        verify(statement).close();
     }
 
     @Test

--- a/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLCloseResourcesTest.java
+++ b/dashbuilder-backend/dashbuilder-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLCloseResourcesTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.sql;
+
+import org.dashbuilder.dataprovider.sql.dialect.Dialect;
+import org.dashbuilder.dataprovider.sql.model.Column;
+import org.dashbuilder.dataprovider.sql.model.Select;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetLookupFactory;
+import org.dashbuilder.dataset.def.SQLDataSetDef;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JDBCUtils.class)
+public class SQLCloseResourcesTest {
+
+    @Mock
+    Connection connection;
+
+    @Mock
+    Statement statement;
+
+    @Mock
+    ResultSet resultSet;
+
+    @Mock
+    Dialect dialect;
+
+    @Mock
+    Select select;
+
+    @Mock
+    SQLDataSourceLocator dataSourceLocator;
+
+    @Mock
+    DataSource dataSource;
+
+    @Mock
+    ResultSetMetaData metaData;
+
+    SQLDataSetProvider sqlDataSetProvider;
+    ResultSetHandler resultSetHandler;
+    SQLDataSetDef dataSetDef = new SQLDataSetDef();
+
+    @Before
+    public void setUp() throws Exception {
+        resultSetHandler = new ResultSetHandler(resultSet, statement);
+        dataSetDef.setDataSource("test");
+        dataSetDef.setDbSQL("test");
+
+        sqlDataSetProvider = SQLDataSetProvider.get();
+        sqlDataSetProvider.setDataSourceLocator(dataSourceLocator);
+        when(dataSourceLocator.lookup(any(SQLDataSetDef.class))).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+
+        PowerMockito.mockStatic(JDBCUtils.class);
+        when(JDBCUtils.dialect(connection)).thenReturn(dialect);
+        when(JDBCUtils.executeQuery(any(Connection.class), anyString())).thenReturn(resultSetHandler);
+    }
+
+    @Test
+    public void testGetColumns() throws Exception {
+        sqlDataSetProvider._getColumns(dataSetDef, connection);
+        verify(statement).close();
+        verify(resultSet).close();
+    }
+
+    @Test
+    public void testLookup() throws Exception {
+        DataSetLookup dataSetLookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                .column("column1")
+                .buildLookup();
+
+        when(JDBCUtils.getColumns(resultSet, null)).thenReturn(Arrays.asList(new Column("column1")));
+        sqlDataSetProvider.lookupDataSet(dataSetDef, dataSetLookup);
+        verify(resultSet, times(3)).close();
+        verify(statement, times(3)).close();
+        verify(connection).close();
+    }
+}


### PR DESCRIPTION
@jhrcek Fix + tests.

As this fix forces to close the opened result sets, the app server no longer warns or auto closes them, regardless the "track-statements" setting of the data source.